### PR TITLE
Make cloudbuild.yaml compatible with a Cloud Build trigger.

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,3 +297,12 @@ An example `install-gpu` step looks like the following:
     - name: 'gcr.io/cos-cloud/cos-customizer'
       args: ['install-gpu',
              '-version=396.26']
+
+
+# Contributor Docs
+
+## Releasing
+
+To release a new version of COS Customizer, tag the commit you want to release
+with the date in the form of `vYYYYMMDD`. This will trigger a Cloud Build job to
+build and release the container image.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,15 +14,16 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/bazel'
-  args: ["test", "--spawn_strategy=standalone", "..."]
+  args: ['test', '--spawn_strategy=standalone', '...']
 - name: 'gcr.io/cloud-builders/bazel'
-  args: ["run", "--spawn_strategy=standalone", ":cos_customizer", "--", "--norun"]
+  args: ['run', '--spawn_strategy=standalone', ':cos_customizer', '--', '--norun']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ["tag", "bazel:cos_customizer", "gcr.io/${PROJECT_ID}/cos-customizer:${COMMIT_SHA}"]
+  args: ['tag', 'bazel:cos_customizer', 'gcr.io/${_OUTPUT_PROJECT}/cos-customizer:${TAG_NAME}']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ["tag", "bazel:cos_customizer", "gcr.io/${PROJECT_ID}/cos-customizer:latest"]
+  args: ['tag', 'bazel:cos_customizer', 'gcr.io/${_OUTPUT_PROJECT}/cos-customizer:latest']
 options:
   machineType: 'N1_HIGHCPU_8'
+  substitutionOption: 'MUST_MATCH'
 images:
-- 'gcr.io/${PROJECT_ID}/cos-customizer:${COMMIT_SHA}'
-- 'gcr.io/${PROJECT_ID}/cos-customizer:latest'
+- 'gcr.io/${_OUTPUT_PROJECT}/cos-customizer:${TAG_NAME}'
+- 'gcr.io/${_OUTPUT_PROJECT}/cos-customizer:latest'


### PR DESCRIPTION
We can configure a Cloud Build trigger to release an image whenever a
commit is tagged. Let's do this to better organize releases.

Fixes #2.