### PR TITLE
Handle empty string license gracefully

### DIFF
--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -51,7 +51,6 @@ go_test(
         "//config:go_default_library",
         "//fakes:go_default_library",
         "//fs:go_default_library",
-        "//gce:go_default_library",
         "@com_github_google_go-cmp//cmp:go_default_library",
         "@com_github_google_subcommands//:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",

--- a/gce/BUILD.bazel
+++ b/gce/BUILD.bazel
@@ -16,9 +16,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "gce.go",
-    ],
+    srcs = ["gce.go"],
     importpath = "cos-customizer/gce",
     visibility = ["//visibility:public"],
     deps = [
@@ -30,9 +28,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = [
-        "gce_test.go",
-    ],
+    srcs = ["gce_test.go"],
     embed = [":go_default_library"],
     deps = [
         "//config:go_default_library",

--- a/preloader/preload.go
+++ b/preloader/preload.go
@@ -181,9 +181,20 @@ func writeDaisyWorkflow(inputWorkflow string, outputImage *config.Image, buildSp
 	return w.Name(), nil
 }
 
+func sanitize(output *config.Image) {
+	var licenses []string
+	for _, l := range output.Licenses {
+		if l != "" {
+			licenses = append(licenses, l)
+		}
+	}
+	output.Licenses = licenses
+}
+
 // daisyArgs computes the parameters to the cos-customizer Daisy workflow (//data/build_image.wf.json)
 // and uploads dependencies to GCS.
 func daisyArgs(ctx context.Context, gcs *gcsManager, files *fs.Files, input *config.Image, output *config.Image, buildSpec *config.Build) ([]string, error) {
+	sanitize(output)
 	toUpload := []string{
 		files.UserBuildContextArchive,
 		files.BuiltinBuildContextArchive,

--- a/preloader/preload_test.go
+++ b/preloader/preload_test.go
@@ -269,6 +269,20 @@ func TestDaisyArgsWorkflowTemplate(t *testing.T) {
 			want:        []byte("[\"license-1\",\"license-2\"]"),
 		},
 		{
+			testName:    "EmptyStringLicense",
+			outputImage: &config.Image{&compute.Image{Licenses: []string{""}}, ""},
+			buildConfig: &config.Build{GCSBucket: "bucket"},
+			workflow:    []byte("{{.Licenses}}"),
+			want:        []byte("null"),
+		},
+		{
+			testName:    "OneEmptyLicense",
+			outputImage: &config.Image{&compute.Image{Licenses: []string{"license-1", ""}}, ""},
+			buildConfig: &config.Build{GCSBucket: "bucket"},
+			workflow:    []byte("{{.Licenses}}"),
+			want:        []byte("[\"license-1\"]"),
+		},
+		{
 			testName:    "Labels",
 			outputImage: &config.Image{&compute.Image{Labels: map[string]string{"key": "value"}}, ""},
 			buildConfig: &config.Build{GCSBucket: "bucket"},


### PR DESCRIPTION
Currently, an empty string license will fail because the GCE API
disallows that. It makes more sense to remove empty string licenses and
allow the build to proceed.

Also run gazelle to clean up some build rules.

Fixes #7.