### PR TITLE
Add expected license format to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ Currently, the COS Customizer is intended to be run as part of a
 sequence of Google Cloud Build build steps. No other usage mode is currently
 supported.
 
-* [Accessing the cos-customizer container image](#accessing-the-cos-customizer-container-image)
-* [Quick Start](#quick-start)
-   * [Minimal example](#minimal-example)
-* [Build Steps](#build-steps)
-   * [Required build steps](#required-build-steps)
-      * [The start-image-build step](#the-start-image-build-step)
-      * [The finish-image-build step](#the-finish-image-build-step)
-   * [Optional build steps](#optional-build-steps)
-      * [run-script](#run-script)
-      * [install-gpu](#install-gpu)
+*   [Accessing the cos-customizer container image](#accessing-the-cos-customizer-container-image)
+*   [Quick Start](#quick-start)
+    *   [Minimal example](#minimal-example)
+*   [Build Steps](#build-steps)
+    *   [Required build steps](#required-build-steps)
+        *   [The start-image-build step](#the-start-image-build-step)
+        *   [The finish-image-build step](#the-finish-image-build-step)
+    *   [Optional build steps](#optional-build-steps)
+        *   [run-script](#run-script)
+        *   [install-gpu](#install-gpu)
 
 ## Accessing the cos-customizer container image
 
@@ -208,8 +208,9 @@ installing GPU drivers requires that GPU quota is available in this zone.
 `-labels`: Key-value pairs to apply to the output image as image labels.
 Example: `-labels=cos_image=true,milestone=65`
 
-`-licenses`: A list of licenses to apply to the output image. Example:
-`-licenses=license1,license2`
+`-licenses`: A list of licenses to apply to the output image. License names must
+be formatted as `projects/{project}/global/licenses/{license}`. Example:
+`-licenses=projects/cos-cloud/global/licenses/cos`
 
 `-inherit-labels`: If present, the output image will be assigned the exact same
 image labels present on the source image. The labels specified by the `-labels`
@@ -297,7 +298,6 @@ An example `install-gpu` step looks like the following:
     - name: 'gcr.io/cos-cloud/cos-customizer'
       args: ['install-gpu',
              '-version=396.26']
-
 
 # Contributor Docs
 

--- a/preloader/preload.go
+++ b/preloader/preload.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"cos-customizer/config"
@@ -185,7 +186,7 @@ func sanitize(output *config.Image) {
 	var licenses []string
 	for _, l := range output.Licenses {
 		if l != "" {
-			licenses = append(licenses, l)
+			licenses = append(licenses, strings.TrimPrefix(l, "https://www.googleapis.com/compute/v1/"))
 		}
 	}
 	output.Licenses = licenses

--- a/preloader/preload_test.go
+++ b/preloader/preload_test.go
@@ -283,6 +283,13 @@ func TestDaisyArgsWorkflowTemplate(t *testing.T) {
 			want:        []byte("[\"license-1\"]"),
 		},
 		{
+			testName:    "URLLicense",
+			outputImage: &config.Image{&compute.Image{Licenses: []string{"https://www.googleapis.com/compute/v1/projects/my-proj/global/licenses/my-license"}}, ""},
+			buildConfig: &config.Build{GCSBucket: "bucket"},
+			workflow:    []byte("{{.Licenses}}"),
+			want:        []byte("[\"projects/my-proj/global/licenses/my-license\"]"),
+		},
+		{
 			testName:    "Labels",
 			outputImage: &config.Image{&compute.Image{Labels: map[string]string{"key": "value"}}, ""},
 			buildConfig: &config.Build{GCSBucket: "bucket"},


### PR DESCRIPTION
Also, strip out the https://... prefix for licenses, if it's there. A
lot of other tools that work with GCE use the URL form to reference
resources. Users may try to use the URL form of the license. This is a
simple thing we can do to improve cos-customizer's behavior when it's
given a license URL.

Also run mdformat on README.md.

Fixes #10.