### PR TITLE
Uprev cos-gpu-installer to support new COS versions.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,9 +38,9 @@ http_archive(
 
 http_archive(
     name = "distroless",
-    sha256 = "87a4d176bf4ceb78f23fe2547cb79dd41b537dcdf477e6da548d3001acb0f47b",
-    strip_prefix = "distroless-a4fd5de337e31911aeee2ad5248284cebeb6a6f4",
-    urls = ["https://github.com/GoogleContainerTools/distroless/archive/a4fd5de337e31911aeee2ad5248284cebeb6a6f4.tar.gz"],
+    sha256 = "14834aaf9e005b9175de2cfa2b420c80778880ee4d9f9a9f7f385d3b177abff7",
+    strip_prefix = "distroless-fa0765cc86064801e42a3b35f50ff2242aca9998",
+    urls = ["https://github.com/GoogleContainerTools/distroless/archive/fa0765cc86064801e42a3b35f50ff2242aca9998.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/data/builtin_build_context/install_gpu.sh
+++ b/data/builtin_build_context/install_gpu.sh
@@ -23,7 +23,7 @@ set -o errexit
 export NVIDIA_DRIVER_VERSION={{.NvidiaDriverVersion}}
 export NVIDIA_DRIVER_MD5SUM={{.NvidiaDriverMd5sum}}
 export NVIDIA_INSTALL_DIR_HOST={{.NvidiaInstallDirHost}}
-export COS_NVIDIA_INSTALLER_CONTAINER=gcr.io/cos-cloud/cos-gpu-installer:v20190523
+export COS_NVIDIA_INSTALLER_CONTAINER=gcr.io/cos-cloud/cos-gpu-installer:v20190806
 export NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia
 export ROOT_MOUNT_DIR=/root
 


### PR DESCRIPTION
Also update WORKSPACE to resolve build failure. Failure had the
following error:

INFO: Call stack for the definition of repository 'package_bundle' which is a _dpkg_list (rule definition at /builder/home/.cache/bazel/_bazel_root/eab0d61a99b6696edb3d2aff87b585e8/external/distroless/package_manager/dpkg.bzl:19:14):
- /builder/home/.cache/bazel/_bazel_root/eab0d61a99b6696edb3d2aff87b585e8/external/distroless/package_manager/dpkg.bzl:74:3
- /workspace/WORKSPACE:173:1
ERROR: An error occurred during the fetch of repository 'package_bundle':
sequence element must be a string (got 'path'). See https://github.com/bazelbuild/bazel/issues/7802 for information about --incompatible_string_join_requires_strings.