### PR TITLE
Update cos-gpu-installer to version v20190820.

### DIFF
--- a/data/builtin_build_context/install_gpu.sh
+++ b/data/builtin_build_context/install_gpu.sh
@@ -23,7 +23,7 @@ set -o errexit
 export NVIDIA_DRIVER_VERSION={{.NvidiaDriverVersion}}
 export NVIDIA_DRIVER_MD5SUM={{.NvidiaDriverMd5sum}}
 export NVIDIA_INSTALL_DIR_HOST={{.NvidiaInstallDirHost}}
-export COS_NVIDIA_INSTALLER_CONTAINER=gcr.io/cos-cloud/cos-gpu-installer:v20190806
+export COS_NVIDIA_INSTALLER_CONTAINER=gcr.io/cos-cloud/cos-gpu-installer:v20190820
 export NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia
 export ROOT_MOUNT_DIR=/root
 


### PR DESCRIPTION
This fixes an issue with md5sum inconsistency. 