### PR TITLE
Makes Daisy's timeout configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ flag take precedence over labels assigned with this flag.
 
 `-disk-size-gb`: The disk size in GB to use when creating the image.
 
+`-timeout`: Timeout value of this step. Must be formatted according to Golang's
+time.Duration string format. Defaults to "60m". Keep in mind that this timeout
+value is different from the overall Cloud Build workflow timeout value, which is
+set at the Cloud Build workflow level. If this timeout value expires, resources
+created during the image build process will be properly cleaned up. If the
+overall Cloud Build workflow timeout expires, the task will be cancelled without
+any opportunity to clean up resources.
+
 An example `finish-image-build` step looks like the following:
 
     - name: 'gcr.io/cos-cloud/cos-customizer'
@@ -298,10 +306,10 @@ An example `install-gpu` step looks like the following:
     - name: 'gcr.io/cos-cloud/cos-customizer'
       args: ['install-gpu',
              '-version=396.26']
-             
-Note that when using an image customized with `install-gpu`, the hosted
-docker container should be set to run in privileged mode so that it has
-access to the GPU device on the host machine.
+
+Note that when using an image customized with `install-gpu`, the hosted docker
+container should be set to run in privileged mode so that it has access to the
+GPU device on the host machine.
 
 # Contributor Docs
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ flag take precedence over labels assigned with this flag.
 `-disk-size-gb`: The disk size in GB to use when creating the image.
 
 `-timeout`: Timeout value of this step. Must be formatted according to Golang's
-time.Duration string format. Defaults to "60m". Keep in mind that this timeout
+time.Duration string format. Defaults to "1h0m0s". Keep in mind that this timeout
 value is different from the overall Cloud Build workflow timeout value, which is
 set at the Cloud Build workflow level. If this timeout value expires, resources
 created during the image build process will be properly cleaned up. If the

--- a/cmd/finish_image_build.go
+++ b/cmd/finish_image_build.go
@@ -46,7 +46,7 @@ type FinishImageBuild struct {
 	licenses       *listVar
 	inheritLabels  bool
 	diskSize       int
-	timeout        string
+	timeout        time.Duration
 }
 
 // Name implements subcommands.Command.Name.
@@ -95,14 +95,11 @@ func (f *FinishImageBuild) SetFlags(flags *flag.FlagSet) {
 		"labels.")
 	flags.IntVar(&f.diskSize, "disk-size-gb", 0, "The disk size to use when creating the image in GB. Value of '0' "+
 		"indicates the default size.")
-	flags.StringVar(&f.timeout, "timeout", "60m", "Timeout value of the image build process. Must be formatted "+
+	flags.DurationVar(&f.timeout, "timeout", time.Hour, "Timeout value of the image build process. Must be formatted "+
 		"according to Golang's time.Duration string format.")
 }
 
 func (f *FinishImageBuild) validate() error {
-	if _, err := time.ParseDuration(f.timeout); err != nil {
-		return fmt.Errorf("'timeout' value is invalid: %q", err)
-	}
 	switch {
 	case f.imageName == "" && f.imageSuffix == "":
 		return fmt.Errorf("one of 'image-name' or 'image-suffix' must be set")
@@ -137,7 +134,7 @@ func (f *FinishImageBuild) loadConfigs(files *fs.Files) (*config.Image, *config.
 	buildConfig.Project = f.project
 	buildConfig.Zone = f.zone
 	buildConfig.DiskSize = f.diskSize
-	buildConfig.Timeout = f.timeout
+	buildConfig.Timeout = f.timeout.String()
 	outputImageConfig := config.NewImage(imageName, f.imageProject)
 	outputImageConfig.Labels = f.labels.m
 	outputImageConfig.Licenses = f.licenses.l

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ type Build struct {
 	Zone      string
 	DiskSize  int
 	GPUType   string
+	Timeout   string
 }
 
 // Save serializes the given struct as JSON and writes it out.

--- a/data/build_image.wf.json
+++ b/data/build_image.wf.json
@@ -1,6 +1,5 @@
 {
   "Name": "build-image",
-  "DefaultTimeout": "60m",
   "Vars": {
     "source_image": {"Required": true, "Description": "URL of the source image to preload."},
     "output_image_name": {"Required": true, "Description": "Name of output image."},

--- a/preloader/preload.go
+++ b/preloader/preload.go
@@ -247,6 +247,8 @@ func daisyArgs(ctx context.Context, gcs *gcsManager, files *fs.Files, input *con
 		buildSpec.Project,
 		"-zone",
 		buildSpec.Zone,
+		"-default_timeout",
+		buildSpec.Timeout,
 		daisyWorkflow,
 	)
 	return args, nil

--- a/preloader/preload_test.go
+++ b/preloader/preload_test.go
@@ -469,6 +469,13 @@ func TestDaisyArgs(t *testing.T) {
 			buildConfig: &config.Build{Zone: "zone", GCSBucket: "bucket", GCSDir: "dir"},
 			want:        []string{"-zone", "zone"},
 		},
+		{
+			testName:    "Timeout",
+			inputImage:  config.NewImage("", ""),
+			outputImage: config.NewImage("", ""),
+			buildConfig: &config.Build{Timeout: "60m", GCSBucket: "bucket", GCSDir: "dir"},
+			want:        []string{"-default_timeout", "60m"},
+		},
 	}
 	gcs := fakes.GCSForTest(t)
 	defer gcs.Close()

--- a/testing/timeout_test.yaml
+++ b/testing/timeout_test.yaml
@@ -18,9 +18,6 @@ steps:
   args:
   - '-c'
   - |
-    if ! gcloud builds submit --config=testing/timeout_test/timeout_test.yaml .; then
-      exit 0
-    else
-      exit 1
-    fi
+    gcloud builds submit --config=testing/timeout_test/timeout_test.yaml . | tee /build.log
+    grep "did not complete within the specified timeout" /build.log > /dev/null
 timeout: '1800s'

--- a/testing/timeout_test.yaml
+++ b/testing/timeout_test.yaml
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    if ! gcloud builds submit --config=testing/timeout_test/timeout_test.yaml .; then
+      exit 0
+    else
+      exit 1
+    fi
+timeout: '1800s'

--- a/testing/timeout_test/preload.sh
+++ b/testing/timeout_test/preload.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sleep 300

--- a/testing/timeout_test/timeout_test.yaml
+++ b/testing/timeout_test/timeout_test.yaml
@@ -1,0 +1,41 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+substitutions:
+  '_TEST': 'timeout_test'
+  '_INPUT_IMAGE': 'cos-dev-69-10895-0-0'
+  '_INPUT_PROJECT': 'cos-cloud'
+steps:
+- name: 'gcr.io/cloud-builders/bazel'
+  args: ['run', '--spawn_strategy=standalone', ':cos_customizer', '--', '--norun']
+- name: 'bazel:cos_customizer'
+  args: ['start-image-build',
+         '-build-context=testing/${_TEST}',
+         '-image-name=${_INPUT_IMAGE}',
+         '-image-project=${_INPUT_PROJECT}',
+         '-gcs-bucket=${PROJECT_ID}_cloudbuild',
+         '-gcs-workdir=customizer-$BUILD_ID']
+- name: 'bazel:cos_customizer'
+  args: ['run-script',
+         '-script=preload.sh']
+- name: 'bazel:cos_customizer'
+  args: ['finish-image-build',
+         '-zone=us-west1-b',
+         '-project=$PROJECT_ID',
+         '-image-name=preload-test-$BUILD_ID',
+         '-image-project=$PROJECT_ID',
+         '-timeout=1m']
+options:
+  machineType: 'N1_HIGHCPU_8'
+timeout: '1500s'


### PR DESCRIPTION
The timeout value is configurable through a 'finish-image-build' flag.
The value of the 'finish-image-build' flag is passed to Daisy's
'default_timeout' flag.

The following packages are modified:
cmd, config: Add the -timeout flag
preloader: Implement timeout behavior
testing: Add integration test for timeout behavior
data: Remove unnecessary DefaultTimeout field in Daisy workflow

This change also adds documentation for the new flag in README.md.