### PR TITLE
Add the --deps-dir flag to install-gpu.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,7 @@ type Build struct {
 	DiskSize  int
 	GPUType   string
 	Timeout   string
+	GCSFiles  []string
 }
 
 // Save serializes the given struct as JSON and writes it out.

--- a/data/build_image.wf.json
+++ b/data/build_image.wf.json
@@ -10,6 +10,10 @@
     "user_build_context": {"Required": true, "Description": "GCS URL of the user build context."},
     "builtin_build_context": {"Required": true, "Description": "GCS URL of the builtin build context."},
     "state_file": {"Required": true, "Description": "GCS URL of the state file."},
+    "gcs_files": {
+      "Required": true,
+      "Description": "GCS URL of the directory containing arbitrary, step-specific data that does not belong in one of the build contexts."
+    },
     "cloud_config": {"Required": true, "Description": "cloud-config file to run."}
   },
   "Sources": {
@@ -39,6 +43,7 @@
             "UserBuildContext": "${user_build_context}",
             "BuiltinBuildContext": "${builtin_build_context}",
             "StateFile": "${state_file}",
+            "GCSFiles": "${gcs_files}",
             "DaisyAck": "${SCRATCHPATH}/daisy_ack",
             "user-data": "${SOURCE:cloud-config}",
             "block-project-ssh-keys": "TRUE",

--- a/testing/gpu_test/gpu_test.yaml
+++ b/testing/gpu_test/gpu_test.yaml
@@ -17,6 +17,7 @@ substitutions:
   "_INPUT_IMAGE": "cos-dev-69-10895-0-0"
   "_INPUT_PROJECT": "cos-cloud"
   "_DRIVER_VERSION": ""
+  "_DEPS_DIR": ""
 steps:
 - name: 'gcr.io/cloud-builders/bazel'
   args: ["run", "--spawn_strategy=standalone", ":cos_customizer", "--", "--norun"]
@@ -33,7 +34,8 @@ steps:
 - name: 'bazel:cos_customizer'
   args: ["install-gpu",
          "-version=${_DRIVER_VERSION}",
-         "-gpu-type=nvidia-tesla-k80"]
+         "-gpu-type=nvidia-tesla-k80",
+         "-deps-dir=${_DEPS_DIR}"]
 - name: 'bazel:cos_customizer'
   args: ["run-script",
          "-script=preload.sh"]

--- a/testing/gpu_test_deps_dir.yaml
+++ b/testing/gpu_test_deps_dir.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/cloud-builders/gsutil'
+  entrypoint: '/bin/bash'
+  args: ["-c", "mkdir deps_dir"]
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ["-m", "cp", "-r", "gs://cos-tools/12998.0.0/*", "deps_dir"]
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: ["builds", "submit", "--config=testing/gpu_test/gpu_test.yaml",
+         "--substitutions=_DRIVER_VERSION=418.67,_INPUT_IMAGE=cos-dev-83-12998-0-0,_DEPS_DIR=deps_dir",
+         "."]
+timeout: "1800s"


### PR DESCRIPTION
This flag allows for injecting cos-gpu-installer data dependencies
through a directory on the Cloud Build worker. This is useful for
building cos-gpu images from pre-release builds.

This flag is implemented by uploading the data dependencies to GCS, and
passing the GCS directory URL to cos-gpu-installer through its
COS_DOWNLOAD_GCS interface.

This change adds an interface to the preloader package that allows any
build step to upload arbitrary files to GCS. The directory containing
these arbitrary files is made available to the preload VM through the
GCSFiles metadata key. The install_gpu preload script accesses the
cos-gpu-installer data dependencies through this metadata key.