### PR TITLE
/testing: Updated test timeouts

### DIFF
--- a/testing/deprecate_test.yaml
+++ b/testing/deprecate_test.yaml
@@ -47,4 +47,4 @@ steps:
   args: ["/workspace/testing/${_TEST}/run_test.sh"]
 options:
   machineType: 'N1_HIGHCPU_8'
-timeout: "1500s"
+timeout: "7200s"

--- a/testing/env_test.yaml
+++ b/testing/env_test.yaml
@@ -42,4 +42,4 @@ steps:
          "-var:test_cfg", "../${_TEST}/preload_test.cfg", "testing/util/run_test.wf.json"]
 options:
   machineType: 'N1_HIGHCPU_8'
-timeout: "1500s"
+timeout: "7200s"

--- a/testing/gpu_test/gpu_test.yaml
+++ b/testing/gpu_test/gpu_test.yaml
@@ -52,4 +52,4 @@ steps:
          "./gpu_vm.wf.json", "testing/util/run_test.wf.json"]
 options:
   machineType: 'N1_HIGHCPU_32'
-timeout: "1500s"
+timeout: "7200s"

--- a/testing/gpu_test_390_46.yaml
+++ b/testing/gpu_test_390_46.yaml
@@ -16,4 +16,4 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ["builds", "submit", "--config=testing/gpu_test/gpu_test.yaml",
          "--substitutions=_DRIVER_VERSION=390.46", "."]
-timeout: "1800s"
+timeout: "7200s"

--- a/testing/gpu_test_396_26.yaml
+++ b/testing/gpu_test_396_26.yaml
@@ -16,4 +16,4 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ["builds", "submit", "--config=testing/gpu_test/gpu_test.yaml",
          "--substitutions=_DRIVER_VERSION=396.26", "."]
-timeout: "1800s"
+timeout: "7200s"

--- a/testing/gpu_test_396_37.yaml
+++ b/testing/gpu_test_396_37.yaml
@@ -16,4 +16,4 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ["builds", "submit", "--config=testing/gpu_test/gpu_test.yaml",
          "--substitutions=_DRIVER_VERSION=396.37", "."]
-timeout: "1800s"
+timeout: "7200s"

--- a/testing/gpu_test_396_44.yaml
+++ b/testing/gpu_test_396_44.yaml
@@ -16,4 +16,4 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ["builds", "submit", "--config=testing/gpu_test/gpu_test.yaml",
          "--substitutions=_DRIVER_VERSION=396.44", "."]
-timeout: "1800s"
+timeout: "7200s"

--- a/testing/gpu_test_deps_dir.yaml
+++ b/testing/gpu_test_deps_dir.yaml
@@ -22,4 +22,4 @@ steps:
   args: ["builds", "submit", "--config=testing/gpu_test/gpu_test.yaml",
          "--substitutions=_DRIVER_VERSION=418.67,_INPUT_IMAGE=cos-dev-83-12998-0-0,_DEPS_DIR=deps_dir",
          "."]
-timeout: "1800s"
+timeout: "7200s"

--- a/testing/image_test.yaml
+++ b/testing/image_test.yaml
@@ -48,4 +48,4 @@ steps:
   args: ["/workspace/testing/${_TEST}/run_test.sh"]
 options:
   machineType: 'N1_HIGHCPU_8'
-timeout: "1500s"
+timeout: "7200s"

--- a/testing/milestone_test.yaml
+++ b/testing/milestone_test.yaml
@@ -38,4 +38,4 @@ steps:
          "-var:test_cfg", "../${_TEST}/preload_test.cfg", "testing/util/run_test.wf.json"]
 options:
   machineType: 'N1_HIGHCPU_8'
-timeout: "1500s"
+timeout: "7200s"

--- a/testing/multi_script_test.yaml
+++ b/testing/multi_script_test.yaml
@@ -44,4 +44,4 @@ steps:
          "-var:test_cfg", "../${_TEST}/preload_test.cfg", "testing/util/run_test.wf.json"]
 options:
   machineType: 'N1_HIGHCPU_8'
-timeout: "1500s"
+timeout: "7200s"

--- a/testing/parallel_test.yaml
+++ b/testing/parallel_test.yaml
@@ -100,4 +100,4 @@ steps:
          "./gpu_vm.wf.json", "testing/util/run_test.wf.json"]
 options:
   machineType: 'N1_HIGHCPU_32'
-timeout: "1500s"
+timeout: "7200s"

--- a/testing/smoke_test.yaml
+++ b/testing/smoke_test.yaml
@@ -41,4 +41,4 @@ steps:
          "-var:test_cfg", "../${_TEST}/preload_test.cfg", "testing/util/run_test.wf.json"]
 options:
   machineType: 'N1_HIGHCPU_8'
-timeout: "1500s"
+timeout: "7200s"

--- a/testing/timeout_test.yaml
+++ b/testing/timeout_test.yaml
@@ -20,4 +20,4 @@ steps:
   - |
     gcloud builds submit --config=testing/timeout_test/timeout_test.yaml . | tee /build.log
     grep "did not complete within the specified timeout" /build.log > /dev/null
-timeout: '1800s'
+timeout: '7200s'

--- a/testing/toolbox_test.yaml
+++ b/testing/toolbox_test.yaml
@@ -41,4 +41,4 @@ steps:
          "-var:test_cfg", "../${_TEST}/preload_test.cfg", "testing/util/run_test.wf.json"]
 options:
   machineType: 'N1_HIGHCPU_8'
-timeout: "1500s"
+timeout: "7200s"


### PR DESCRIPTION
Currently, running all tests often results in some tests timing out. This is because a single Cloud Build project can only run at most 10 jobs in parallel, and time spent queued counts towards a job’s timeout. Let’s increase the timeout value to better handle the tests that we have. 7200s is 2 hours, which is a comfortably long time to run all of the tests.