### PR TITLE
Make sure that a unit exists before stopping it.

### DIFF
--- a/data/startup.sh
+++ b/data/startup.sh
@@ -210,13 +210,27 @@ execute_state_file() {
   echo "Done running preload scripts."
 }
 
+stop_service() {
+  local -r name="$1"
+  # We don't want to call `systemctl stop` on a unit that doesn't exist.
+  # `systemctl is-active` is a good enough proxy for that, so let's use that to
+  # avoid calling `systemctl stop` on a unit that doesn't exist.
+  if systemctl -q is-active "${name}"; then
+    echo "${name} is active, stopping..."
+    systemctl stop "${name}"
+    echo "${name} stopped"
+  else
+    echo "${name} is not active, ignoring"
+  fi
+}
+
 stop_services() {
   echo "Stopping services..."
-  systemctl stop crash-reporter
-  systemctl stop crash-sender
-  systemctl stop device_policy_manager
-  systemctl stop metrics-daemon
-  systemctl stop update-engine
+  stop_service crash-reporter
+  stop_service crash-sender
+  stop_service device_policy_manager
+  stop_service metrics-daemon
+  stop_service update-engine
   echo "Done stopping services."
 }
 


### PR DESCRIPTION
If we stop a unit that doesn't exist, `systemctl stop` will return a
non-zero exit code, resulting in a failed build. This causes issues when
we remove units in new milestones.

We use `systemctl is-active` to determine if we need to stop the unit or
not. This isn't the same thing as checking if the unit exists, but it's
good enough in this case because we really only want to stop the unit if
it is active.