### PR TITLE
cloudbuild.yaml: release will not test tools/...

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/bazel'
-  args: ['test', '--spawn_strategy=standalone', '...']
+  args: ['test', '--spawn_strategy=standalone','--','...','-tools/...']
 - name: 'gcr.io/cloud-builders/bazel'
   args: ['run', '--spawn_strategy=standalone', ':cos_customizer', '--', '--norun']
 - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
Currently the release workflow run `bazel test` on
all tests in the workspace. However, the tests
of programs related to disk partitions need to setup
loop devices. In cloud build VM, the loop device can
not be correctly set or it cannot be accessed directly
from an Ubuntu container. So we skip tests in tools/
to make sure the release workflow run successfully.

Tests in tools/ and tools/partutils/ should be
tested manually with root permission.