### PR TITLE
Add support for passing in an nvidia installer

### DIFF
--- a/cmd/install_gpu_test.go
+++ b/cmd/install_gpu_test.go
@@ -281,3 +281,16 @@ func TestInstallGPUStateFile(t *testing.T) {
 		t.Errorf("install-gpu(_); state file; got %s, want %s", string(got), string(want))
 	}
 }
+
+func TestInstallGPUInstallerWithoutDepsDir(t *testing.T) {
+	tmpDir, files, err := setupInstallGPUFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	gcs := fakes.GCSForTest(t)
+	defer gcs.Close()
+	if _, err := executeInstallGPU(context.Background(), files, gcs.Client, "-version=NVIDIA-Linux-x86_64-450.51.06.run"); err == nil {
+		t.Error("install-gpu(-version=NVIDIA-Linux-x86_64-450.51.06.run); got nil, want error")
+	}
+}

--- a/data/builtin_build_context/install_gpu.sh
+++ b/data/builtin_build_context/install_gpu.sh
@@ -60,7 +60,7 @@ main() {
   mount --bind "${NVIDIA_INSTALL_DIR_HOST}" "${NVIDIA_INSTALL_DIR_HOST}"
   mount -o remount,exec "${NVIDIA_INSTALL_DIR_HOST}"
   pull_installer
-  docker run \
+  if ! docker run \
     --rm \
     --privileged \
     --net=host \
@@ -75,7 +75,11 @@ main() {
     -e NVIDIA_INSTALL_DIR_CONTAINER \
     -e ROOT_MOUNT_DIR \
     -e COS_DOWNLOAD_GCS \
-    "${COS_NVIDIA_INSTALLER_CONTAINER}"
+    "${COS_NVIDIA_INSTALLER_CONTAINER}"; then
+    echo "GPU install failed. Nvidia installer debug logs:"
+    cat /var/lib/nvidia/nvidia-installer.log
+    return 1
+  fi
   ${NVIDIA_INSTALL_DIR_HOST}/bin/nvidia-smi
 
   # Start nvidia-persistenced

--- a/testing/gpu_test_deps_dir.yaml
+++ b/testing/gpu_test_deps_dir.yaml
@@ -18,6 +18,8 @@ steps:
   args: ["-c", "mkdir deps_dir"]
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ["-m", "cp", "-r", "gs://cos-tools/12998.0.0/*", "deps_dir"]
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ["-m", "cp", "gs://nvidia-drivers-us-public/tesla/418.67/NVIDIA-Linux-x86_64-418.67.run", "deps_dir"]
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ["builds", "submit", "--config=testing/gpu_test/gpu_test.yaml",
          "--substitutions=_DRIVER_VERSION=418.67,_INPUT_IMAGE=cos-dev-83-12998-0-0,_DEPS_DIR=deps_dir",


### PR DESCRIPTION
For certain types of pre-release images, it is useful to be able to
choose the exact nvidia installer that we build with. This change allows
users to specify an nvidia installer in the 'install-gpu' step. The
installer must be specified in the '-version' flag, and if an installer
is specified, it must be available in the '-deps-dir' directory.