### PR TITLE
Add support for passing in an nvidia installer

### DIFF
--- a/cmd/install_gpu.go
+++ b/cmd/install_gpu.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -72,7 +73,8 @@ func (*InstallGPU) Usage() string {
 
 // SetFlags implements subcommands.Command.SetFlags.
 func (i *InstallGPU) SetFlags(f *flag.FlagSet) {
-	f.StringVar(&i.NvidiaDriverVersion, "version", "", "Driver version to install.")
+	f.StringVar(&i.NvidiaDriverVersion, "version", "", "Driver version to install. Can also be the name of an nvidia installer present in the "+
+		"directory specified by '-deps-dir'; e.g., NVIDIA-Linux-x86_64-450.51.06.run.")
 	f.StringVar(&i.NvidiaDriverMd5sum, "md5sum", "", "Md5sum of the driver to install.")
 	f.StringVar(&i.NvidiaInstallDirHost, "install-dir", "/var/lib/nvidia",
 		"Location to install drivers on the image.")
@@ -131,16 +133,31 @@ func (i *InstallGPU) validate(ctx context.Context, gcsClient *storage.Client, fi
 	if gpuAlreadyConf {
 		return fmt.Errorf("install-gpu can only be invoked once in an image build process. Only one driver version can be installed on the image")
 	}
-	validDrivers, err := validDriverVersions(ctx, gcsClient)
-	if err != nil {
-		return err
-	}
-	if !validDrivers[i.NvidiaDriverVersion] {
-		var drivers []string
-		for d := range validDrivers {
-			drivers = append(drivers, d)
+	if strings.HasSuffix(i.NvidiaDriverVersion, ".run") {
+		log.Printf("driver version is set to %q, which looks like an nvidia installer file", i.NvidiaDriverVersion)
+		if i.gpuDataDir == "" {
+			return errors.New(`"-deps-dir" must be set when the version is specified as an nvidia installer file`)
 		}
-		return fmt.Errorf("driver version %s is not valid; valid driver versions are: %v", i.NvidiaDriverVersion, drivers)
+		fileName := filepath.Join(i.gpuDataDir, i.NvidiaDriverVersion)
+		info, err := os.Stat(fileName)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("nvidia installer file at %q does not exist", fileName)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("nvidia installer file at %q is a directory", fileName)
+		}
+	} else {
+		validDrivers, err := validDriverVersions(ctx, gcsClient)
+		if err != nil {
+			return err
+		}
+		if !validDrivers[i.NvidiaDriverVersion] {
+			var drivers []string
+			for d := range validDrivers {
+				drivers = append(drivers, d)
+			}
+			return fmt.Errorf("driver version %s is not valid; valid driver versions are: %v", i.NvidiaDriverVersion, drivers)
+		}
 	}
 	return nil
 }

--- a/cmd/install_gpu_test.go
+++ b/cmd/install_gpu_test.go
@@ -281,3 +281,16 @@ func TestInstallGPUStateFile(t *testing.T) {
 		t.Errorf("install-gpu(_); state file; got %s, want %s", string(got), string(want))
 	}
 }
+
+func TestInstallGPUInstallerWithoutDepsDir(t *testing.T) {
+	tmpDir, files, err := setupInstallGPUFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	gcs := fakes.GCSForTest(t)
+	defer gcs.Close()
+	if _, err := executeInstallGPU(context.Background(), files, gcs.Client, "-version=NVIDIA-Linux-x86_64-450.51.06.run"); err == nil {
+		t.Error("install-gpu(-version=NVIDIA-Linux-x86_64-450.51.06.run); got nil, want error")
+	}
+}

--- a/data/builtin_build_context/install_gpu.sh
+++ b/data/builtin_build_context/install_gpu.sh
@@ -35,6 +35,18 @@ set_cos_download_gcs() {
   fi
 }
 
+set_gpu_installer_download_url() {
+  if [[ ! "${NVIDIA_DRIVER_VERSION}" == *.run ]]; then
+    return
+  fi
+  if [[ -n "${COS_DOWNLOAD_GCS}" ]]; then
+    export GPU_INSTALLER_DOWNLOAD_URL=\
+"${COS_DOWNLOAD_GCS}/${NVIDIA_DRIVER_VERSION}"
+  fi
+  # NVIDIA-Linux-x86_64-450.51.06.run -> 450.51.06
+  NVIDIA_DRIVER_VERSION="$(echo "${NVIDIA_DRIVER_VERSION%.run}" | cut -d '-' -f 4)"
+}
+
 pull_installer() {
   local docker_code
   local i=1
@@ -56,6 +68,7 @@ main() {
   if [[ -n "${SET_COS_DOWNLOAD_GCS}" ]]; then
     set_cos_download_gcs
   fi
+  set_gpu_installer_download_url
   mkdir -p "${NVIDIA_INSTALL_DIR_HOST}"
   mount --bind "${NVIDIA_INSTALL_DIR_HOST}" "${NVIDIA_INSTALL_DIR_HOST}"
   mount -o remount,exec "${NVIDIA_INSTALL_DIR_HOST}"
@@ -75,6 +88,7 @@ main() {
     -e NVIDIA_INSTALL_DIR_CONTAINER \
     -e ROOT_MOUNT_DIR \
     -e COS_DOWNLOAD_GCS \
+    -e GPU_INSTALLER_DOWNLOAD_URL \
     ${COS_NVIDIA_INSTALLER_CONTAINER}"
   if ! ${docker_run_cmd}; then
     echo "GPU install failed."

--- a/testing/gpu_test/gpu_test.yaml
+++ b/testing/gpu_test/gpu_test.yaml
@@ -21,9 +21,18 @@ substitutions:
 steps:
 - name: 'gcr.io/cloud-builders/bazel'
   args: ["run", "--spawn_strategy=standalone", ":cos_customizer", "--", "--norun"]
-- name: 'busybox'
-  args: ["sed", "-i", "-e", "s|%s|'${_DRIVER_VERSION}'|",
-         "testing/${_TEST}/preload_test.cfg"]
+- name: 'ubuntu'
+  args: 
+  - bash
+  - -c
+  - |
+    ver="${_DRIVER_VERSION}"
+    if [[ "${ver}" == *.run ]]; then
+      sub="$(echo "${ver%.run}" | cut -d '-' -f 4)"
+    else
+      sub="${ver}"
+    fi
+    sed -i -e "s|%s|'${sub}'|" testing/${_TEST}/preload_test.cfg
 - name: 'bazel:cos_customizer'
   args: ["start-image-build",
          "-build-context=testing/${_TEST}",

--- a/testing/gpu_test_deps_dir.yaml
+++ b/testing/gpu_test_deps_dir.yaml
@@ -18,8 +18,10 @@ steps:
   args: ["-c", "mkdir deps_dir"]
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ["-m", "cp", "-r", "gs://cos-tools/12998.0.0/*", "deps_dir"]
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ["-m", "cp", "gs://nvidia-drivers-us-public/tesla/418.67/NVIDIA-Linux-x86_64-418.67.run", "deps_dir"]
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ["builds", "submit", "--config=testing/gpu_test/gpu_test.yaml",
-         "--substitutions=_DRIVER_VERSION=418.67,_INPUT_IMAGE=cos-dev-83-12998-0-0,_DEPS_DIR=deps_dir",
+         "--substitutions=_DRIVER_VERSION=NVIDIA-Linux-x86_64-418.67.run,_INPUT_IMAGE=cos-dev-83-12998-0-0,_DEPS_DIR=deps_dir",
          "."]
 timeout: "7200s"

--- a/testing/parallel_test.yaml
+++ b/testing/parallel_test.yaml
@@ -16,7 +16,7 @@ substitutions:
   "_TEST_1": "smoke_test"
   "_INPUT_IMAGE_1": "cos-dev-69-10895-0-0"
   "_TEST_2": "gpu_test"
-  "_INPUT_IMAGE_2": "cos-dev-69-10895-27-0"
+  "_INPUT_IMAGE_2": "cos-69-10895-71-0"
   "_INPUT_PROJECT": "cos-cloud"
 steps:
 - name: 'gcr.io/cloud-builders/bazel'


### PR DESCRIPTION
For certain types of pre-release images, it is useful to be able to
choose the exact nvidia installer that we build with. This change allows
users to specify an nvidia installer in the 'install-gpu' step. The
installer must be specified in the '-version' flag, and if an installer
is specified, it must be available in the '-deps-dir' directory.