### PR TITLE
Add the "provisioner" command line tool

### DIFF
--- a/src/cmd/provisioner/BUILD.bazel
+++ b/src/cmd/provisioner/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "main.go",
+        "run.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/cmd/provisioner",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_google_subcommands//:go_default_library"],
+)
+
+go_binary(
+    name = "provisioner",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/src/cmd/provisioner/main.go
+++ b/src/cmd/provisioner/main.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// provisioner is a tool for provisioning COS instances. The tool is intended to
+// run on a running COS machine.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/google/subcommands"
+)
+
+var (
+	stateDir = flag.String("state-dir", "/var/lib/.cos-customizer", "Absolute path to the directory to use for provisioner state. "+
+		"This directory is used for persisting internal state across reboots, unpacking inputs, and running provisioning scripts. "+
+		"The size of the directory scales with the size of the inputs.")
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	subcommands.Register(subcommands.HelpCommand(), "")
+	subcommands.Register(subcommands.FlagsCommand(), "")
+	subcommands.Register(&Run{}, "")
+	flag.Parse()
+	ctx := context.Background()
+	ret := int(subcommands.Execute(ctx))
+	os.Exit(ret)
+}

--- a/src/cmd/provisioner/run.go
+++ b/src/cmd/provisioner/run.go
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log"
+
+	"github.com/google/subcommands"
+)
+
+// Run implements subcommands.Command for the "run" command.
+// This command runs the provisioner from a provided configuration file.
+type Run struct {
+	configPath string
+}
+
+// Name implements subcommands.Command.Name.
+func (r *Run) Name() string {
+	return "run"
+}
+
+// Synopsis implements subcommands.Command.Synopsis.
+func (r *Run) Synopsis() string {
+	return "Provision a COS instance from the provided configuration file."
+}
+
+// Usage implements subcommands.Command.Usage.
+func (r *Run) Usage() string {
+	return `run [flags]
+`
+}
+
+// SetFlags implements subcommands.Command.SetFlags.
+func (r *Run) SetFlags(f *flag.FlagSet) {
+	f.StringVar(&r.configPath, "config", "", "Path to a configuration file to use for provisioning.")
+}
+
+func (r *Run) validate() error {
+	if r.configPath == "" {
+		return errors.New("-config must be provided")
+	}
+	return nil
+}
+
+// Execute implements subcommands.Command.Execute.
+func (r *Run) Execute(_ context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+	if err := r.validate(); err != nil {
+		log.Printf("Error in flags: %v", err)
+		return subcommands.ExitFailure
+	}
+	return subcommands.ExitSuccess
+}


### PR DESCRIPTION
Currently, cos-customizer's on-instance provisioning behavior is
implemented in a startup script called "startup.sh". This script has
become pretty complicated in a number of ways, and is now very brittle.
Changes to that script need to be made very carefully and need to
account for subtle behaviors in bash and COS. Additionally, startup.sh
depends on COS-on-GCP-specific behaviors, like the get_metadata_value
script.

We can address these issues by moving almost all of the startup.sh
behaviors into a Go program. This will help with brittleness issues by:
- Having clear error handling behavior
- Having well-defined and explicit interfaces
- Removing dependencies on the base OS
- Removing the dependency on a Python container image
- Not needing to deal with bash `trap` builtin subtleties
- Having compile-time checks catch basic problems
- Giving us a standard way to write unit tests

The "provisioner" command line tool will be this Go program. The
interface will look like the following (subject to change as per code
reviews and implementation unknowns, of course):

./provisioner run --config=config.json
The run subcommand runs the provisioning behavior from a configuration
file. This configuration file is a replacement for startup.sh's state
file + GCE metadata flags.

./provisioner resume
The resume subcommand resumes an interrupted provisioning flow. This is
how we will handle provisioning steps that require rebooting the VM.

./provisioner status
The status subcommand gives the status of an in-progress provisioning
flow. This is how we know if there is an in-progress provisioning flow
or not, and helps the user know if `resume` makes sense.

All subcommands will take the --state-dir flag, which points to a
directory where the provisioner will store persistent state. This
replaces startup.sh's random files in /mnt/stateful_partition and
/var/lib/.cos-customizer.

This commit adds some bare files for the utility, and doesn't implement
any real behavior. Subsequent commits will implement the full behavior.