### PR TITLE
Add a provisioner library in pkg/

### DIFF
--- a/src/cmd/provisioner/BUILD.bazel
+++ b/src/cmd/provisioner/BUILD.bazel
@@ -8,7 +8,10 @@ go_library(
     ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/cmd/provisioner",
     visibility = ["//visibility:private"],
-    deps = ["@com_github_google_subcommands//:go_default_library"],
+    deps = [
+        "//src/pkg/provisioner:go_default_library",
+        "@com_github_google_subcommands//:go_default_library",
+    ],
 )
 
 go_binary(

--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config.go",
+        "provisioner.go",
+        "state.go",
+    ],
+    importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["provisioner_test.go"],
+    embed = [":go_default_library"],
+)

--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -1,0 +1,58 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+// Config defines a provisioning flow.
+type Config struct {
+	// BuildContexts identifies the build contexts that should be used during
+	// provisioning. A build context means the same thing here as it does
+	// elsewhere in cos-customizer. The keys are build context identifiers, and
+	// the values are addresses to fetch the build contexts from. Currently, only
+	// gs:// addresses are supported.
+	BuildContexts map[string]string
+	// BootDisk defines how the boot disk should be configured.
+	BootDisk struct {
+		StatefulSize string
+		OEMSize      string
+		ReclaimSDA3  string
+		VerifiedOEM  bool
+	}
+	// Steps are provisioning behaviors that can be run.
+	// The supported provisioning behaviors are:
+	//
+	// Type: RunScript
+	// Args:
+	// - BuildContext: the name of the build contex to run the script in
+	// - Path: the path to the script in the build context
+	// - Env: Environment variables to pass to the script, in the format
+	//   A=B,C=D
+	//
+	// Type: InstallGPU
+	// Args:
+	// - Version: The nvidia driver version to install
+	// - MD5Sum: An optional md5 hash to use to verify the downloaded nvidia
+	//   installer
+	// - InstallDir: An absolute path to install nvidia drivers in to
+	// - GCSDownloadPrefix: A optional gs:// URI that will be used as a prefix
+	//   for downloading cos-gpu-installer dependencies.
+	//
+	// Type: AppendKernelCmdLine
+	// Args:
+	// - Value: The exact text to append to the kernel command line.
+	Steps []struct {
+		Type string
+		Args map[string]string
+	}
+}

--- a/src/pkg/provisioner/provisioner.go
+++ b/src/pkg/provisioner/provisioner.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package provisioner exports behaviors for provisioning COS systems
+// end-to-end. These behaviors are intended to run on a COS system.
+package provisioner
+
+import (
+	"fmt"
+	"os"
+)
+
+func cleanup(stateDir string) error {
+	return os.RemoveAll(stateDir)
+}
+
+// Run runs a full provisioning flow based on the provided config. The stateDir
+// is used for persisting data used as part of provisioning. The stateDir allows
+// the provisioning flow to be interrupted (e.g. by a reboot) and resumed.
+func Run(stateDir string, c Config) (err error) {
+	if _, err := initState(stateDir, c); err != nil {
+		return err
+	}
+	// TODO(rkolchmeyer): Implement the actual provisioning behavior
+	if err := cleanup(stateDir); err != nil {
+		return fmt.Errorf("error in cleanup: %v", err)
+	}
+	return nil
+}

--- a/src/pkg/provisioner/provisioner_test.go
+++ b/src/pkg/provisioner/provisioner_test.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStateExists(t *testing.T) {
+	dir, err := ioutil.TempDir("", "provisioner-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	if err := ioutil.WriteFile(filepath.Join(dir, "state.json"), []byte("{}"), 0660); err != nil {
+		t.Fatal(err)
+	}
+	config := Config{}
+	if err := Run(dir, config); err != errStateAlreadyExists {
+		t.Fatalf("Run(%s, %+v) = %v; want %v", dir, config, err, errStateAlreadyExists)
+	}
+}

--- a/src/pkg/provisioner/state.go
+++ b/src/pkg/provisioner/state.go
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+var (
+	errStateAlreadyExists = errors.New("state already exists")
+)
+
+type stateData struct {
+	Config      Config
+	CurrentStep int
+}
+
+type state struct {
+	dir  string
+	data stateData
+}
+
+func (s *state) dataPath() string {
+	return filepath.Join(s.dir, "state.json")
+}
+
+func (s *state) write() error {
+	data, err := json.Marshal(&s.data)
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON: %v", err)
+	}
+	if err := ioutil.WriteFile(s.dataPath(), data, 0660); err != nil {
+		return fmt.Errorf("error writing %q: %v", s.dataPath(), err)
+	}
+	return nil
+}
+
+func initState(dir string, c Config) (*state, error) {
+	s := &state{dir: dir, data: stateData{Config: c, CurrentStep: 0}}
+	if _, err := os.Stat(s.dataPath()); err == nil {
+		return nil, errStateAlreadyExists
+	}
+	if err := os.MkdirAll(dir, 0770); err != nil {
+		return nil, fmt.Errorf("error creating directory %q: %v", dir, err)
+	}
+	if err := s.write(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}


### PR DESCRIPTION
To help with reusability and testability, lets implement the bulk of the
provisioner behavior in a library.

This change adds some bare behavior to `provisioner run` for initializing
provisioner state in the state directory.