### PR TITLE
provisioner: add additional setup behavior

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.5.4
 	github.com/google/subcommands v1.2.0
 	golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 	google.golang.org/api v0.39.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/src/cmd/provisioner/BUILD.bazel
+++ b/src/cmd/provisioner/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//src/pkg/provisioner:go_default_library",
         "@com_github_google_subcommands//:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
     ],
 )
 

--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -6,9 +6,15 @@ go_library(
         "config.go",
         "provisioner.go",
         "state.go",
+        "systemd.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner",
     visibility = ["//visibility:public"],
+    deps = [
+        "//src/pkg/utils:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
 )
 
 go_test(

--- a/src/pkg/provisioner/provisioner.go
+++ b/src/pkg/provisioner/provisioner.go
@@ -17,24 +17,71 @@
 package provisioner
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"os"
+	"os/exec"
+
+	"cloud.google.com/go/storage"
+	"golang.org/x/sys/unix"
 )
 
+func setup(dockerCredentialGCR string, systemd *systemdClient) error {
+	log.Println("Setting up environment...")
+	if err := systemd.stop("update-engine.service"); err != nil {
+		return err
+	}
+	if err := unix.Mount("", "/root", "tmpfs", 0, ""); err != nil {
+		return fmt.Errorf("error mounting tmpfs at /root: %v", err)
+	}
+	cmd := exec.Command(dockerCredentialGCR, "configure-docker")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error in cmd docker-credential-gcr, see stderr for details: %v", err)
+	}
+	log.Println("Done setting up the environment")
+	return nil
+}
+
 func cleanup(stateDir string) error {
-	return os.RemoveAll(stateDir)
+	log.Println("Cleaning up machine state...")
+	if err := os.RemoveAll(stateDir); err != nil {
+		return err
+	}
+	log.Println("Done cleaning up machine state")
+	return nil
+}
+
+// Deps contains provisioner service dependencies.
+type Deps struct {
+	// GCSClient is used to access Google Cloud Storage.
+	GCSClient *storage.Client
+	// TarCmd is used for tar.
+	TarCmd string
+	// SystemctlCmd is used to access systemd.
+	SystemctlCmd string
+	// DockerCredentialGCR is the path to the docker-credential-gcr binary.
+	DockerCredentialGCR string
 }
 
 // Run runs a full provisioning flow based on the provided config. The stateDir
 // is used for persisting data used as part of provisioning. The stateDir allows
 // the provisioning flow to be interrupted (e.g. by a reboot) and resumed.
-func Run(stateDir string, c Config) (err error) {
-	if _, err := initState(stateDir, c); err != nil {
+func Run(ctx context.Context, deps Deps, stateDir string, c Config) (err error) {
+	log.Println("Provisioning machine...")
+	systemd := &systemdClient{systemctl: deps.SystemctlCmd}
+	if _, err := initState(ctx, deps, stateDir, c); err != nil {
+		return err
+	}
+	if err := setup(deps.DockerCredentialGCR, systemd); err != nil {
 		return err
 	}
 	// TODO(rkolchmeyer): Implement the actual provisioning behavior
 	if err := cleanup(stateDir); err != nil {
 		return fmt.Errorf("error in cleanup: %v", err)
 	}
+	log.Println("Done provisioning machine")
 	return nil
 }

--- a/src/pkg/provisioner/provisioner_test.go
+++ b/src/pkg/provisioner/provisioner_test.go
@@ -15,6 +15,7 @@
 package provisioner
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 )
 
 func TestStateExists(t *testing.T) {
+	ctx := context.Background()
 	dir, err := ioutil.TempDir("", "provisioner-test-")
 	if err != nil {
 		t.Fatal(err)
@@ -30,8 +32,13 @@ func TestStateExists(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(dir, "state.json"), []byte("{}"), 0660); err != nil {
 		t.Fatal(err)
 	}
+	deps := Deps{
+		GCSClient:    nil,
+		TarCmd:       "",
+		SystemctlCmd: "",
+	}
 	config := Config{}
-	if err := Run(dir, config); err != errStateAlreadyExists {
-		t.Fatalf("Run(%s, %+v) = %v; want %v", dir, config, err, errStateAlreadyExists)
+	if err := Run(ctx, deps, dir, config); err != errStateAlreadyExists {
+		t.Fatalf("Run(ctx, %+v, %q, %+v) = %v; want %v", deps, dir, config, err, errStateAlreadyExists)
 	}
 }

--- a/src/pkg/provisioner/systemd.go
+++ b/src/pkg/provisioner/systemd.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+)
+
+type systemdClient struct {
+	systemctl string
+}
+
+func (sc *systemdClient) isActive(unit string) bool {
+	return exec.Command(sc.systemctl, "is-active", unit).Run() == nil
+}
+
+func (sc *systemdClient) stop(unit string) error {
+	if sc.isActive(unit) {
+		log.Printf("%q is active, stopping...", unit)
+		args := []string{"stop", unit}
+		cmd := exec.Command(sc.systemctl, args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf(`error in cmd "%s %v", see stderr for details: %v`, sc.systemctl, args, err)
+		}
+		log.Printf("%q stopped", unit)
+	} else {
+		log.Printf("%q is not active, ignoring", unit)
+	}
+	return nil
+}

--- a/src/pkg/utils/BUILD.bazel
+++ b/src/pkg/utils/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["utils.go"],
+    importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils",
+    visibility = ["//visibility:public"],
+)

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utils exports generally useful functionality.
+package utils
+
+import (
+	"fmt"
+	"io"
+	"log"
+)
+
+// CheckClose closes an io.Closer and checks its error. Useful for checking the
+// errors on deferred Close() behaviors.
+func CheckClose(closer io.Closer, errMsgOnClose string, err *error) {
+	if closeErr := closer.Close(); closeErr != nil {
+		var fullErr error
+		if errMsgOnClose != "" {
+			fullErr = fmt.Errorf("%s: %v", errMsgOnClose, closeErr)
+		} else {
+			fullErr = closeErr
+		}
+		if *err == nil {
+			*err = fullErr
+		} else {
+			log.Println(fullErr)
+		}
+	}
+}


### PR DESCRIPTION
As part of setup, we need to download the build contexts, stop update
engine, and run docker-credential-gcr.