### PR TITLE
provisioner: Add more comprehensive testing

### DIFF
--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -21,5 +21,10 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["provisioner_test.go"],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    deps = [
+        "//src/pkg/fakes:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
 )

--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -58,7 +58,7 @@ type Config struct {
 	// - Value: The exact text to append to the kernel command line.
 	Steps []struct {
 		Type string
-		Args *json.RawMessage
+		Args json.RawMessage
 	}
 }
 
@@ -66,12 +66,12 @@ type step interface {
 	run(*state) error
 }
 
-func parseStep(stepType string, stepArgs *json.RawMessage) (step, error) {
+func parseStep(stepType string, stepArgs json.RawMessage) (step, error) {
 	switch stepType {
 	case "RunScript":
 		var s step
 		s = &runScriptStep{}
-		if err := json.Unmarshal(*stepArgs, s); err != nil {
+		if err := json.Unmarshal(stepArgs, s); err != nil {
 			return nil, err
 		}
 		return s, nil

--- a/src/pkg/provisioner/provisioner_test.go
+++ b/src/pkg/provisioner/provisioner_test.go
@@ -16,11 +16,40 @@ package provisioner
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/fakes"
+	"golang.org/x/sys/unix"
 )
+
+func testDataDir(t *testing.T) string {
+	t.Helper()
+	path, err := filepath.Abs("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func stubMount() {
+	mountFunc = func(a1, a2, a3 string, a4 uintptr, a5 string) error {
+		return nil
+	}
+	unmountFunc = func(a1 string, a2 int) error {
+		return nil
+	}
+}
+
+func restoreMount() {
+	mountFunc = unix.Mount
+	unmountFunc = unix.Unmount
+}
 
 func TestStateExists(t *testing.T) {
 	ctx := context.Background()
@@ -40,5 +69,208 @@ func TestStateExists(t *testing.T) {
 	config := Config{}
 	if err := Run(ctx, deps, dir, config); err != errStateAlreadyExists {
 		t.Fatalf("Run(ctx, %+v, %q, %+v) = %v; want %v", deps, dir, config, err, errStateAlreadyExists)
+	}
+}
+
+func TestRunInvalidArgs(t *testing.T) {
+	stubMount()
+	t.Cleanup(restoreMount)
+	tests := []struct {
+		name   string
+		config Config
+	}{
+		{
+			name: "RunScript",
+			config: Config{
+				Steps: []struct {
+					Type string
+					Args json.RawMessage
+				}{
+					{
+						Type: "RunScript",
+						Args: []byte("{}"),
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			tempDir, err := ioutil.TempDir("", "provisioner-test-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+			gcs := fakes.GCSForTest(t)
+			deps := Deps{
+				GCSClient:           gcs.Client,
+				TarCmd:              "tar",
+				SystemctlCmd:        "/bin/true",
+				RootDir:             tempDir,
+				DockerCredentialGCR: "/bin/true",
+			}
+			stateDir := filepath.Join(tempDir, "var", "lib", ".cos-customizer")
+			funcCall := fmt.Sprintf("Run(ctx, %+v, %q, %+v)", deps, stateDir, test.config)
+			if err := Run(ctx, deps, stateDir, test.config); err == nil {
+				t.Fatalf("%s = nil; want invalid args", funcCall)
+			}
+		})
+	}
+}
+
+func TestRunFailure(t *testing.T) {
+	stubMount()
+	t.Cleanup(restoreMount)
+	testData := testDataDir(t)
+	buildCtxDir, err := ioutil.TempDir("", "provisioner-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(buildCtxDir) })
+	buildCtx := filepath.Join(buildCtxDir, "test.tar")
+	if err := exec.Command("tar", "cf", buildCtx, "-C", filepath.Join(testData, "test_ctx"), ".").Run(); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name       string
+		gcsObjects map[string]string
+		config     Config
+	}{
+		{
+			name: "RunScript",
+			gcsObjects: map[string]string{
+				"/test/test.tar": buildCtx,
+			},
+			config: Config{
+				BuildContexts: map[string]string{
+					"bc": "gs://test/test.tar",
+				},
+				Steps: []struct {
+					Type string
+					Args json.RawMessage
+				}{
+					{
+						Type: "RunScript",
+						Args: []byte(`{"BuildContext": "bc", "Path": "run_env.sh"}`),
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			tempDir, err := ioutil.TempDir("", "provisioner-test-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+			gcs := fakes.GCSForTest(t)
+			for name, path := range test.gcsObjects {
+				data, err := ioutil.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gcs.Objects[name] = data
+			}
+			deps := Deps{
+				GCSClient:           gcs.Client,
+				TarCmd:              "tar",
+				SystemctlCmd:        "/bin/true",
+				RootDir:             tempDir,
+				DockerCredentialGCR: "/bin/true",
+			}
+			stateDir := filepath.Join(tempDir, "var", "lib", ".cos-customizer")
+			funcCall := fmt.Sprintf("Run(ctx, %+v, %q, %+v)", deps, stateDir, test.config)
+			if err := Run(ctx, deps, stateDir, test.config); err == nil {
+				t.Fatalf("%s = nil; want err", funcCall)
+			}
+		})
+	}
+}
+
+func TestRunSuccess(t *testing.T) {
+	stubMount()
+	t.Cleanup(restoreMount)
+	testData := testDataDir(t)
+	buildCtxDir, err := ioutil.TempDir("", "provisioner-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(buildCtxDir) })
+	buildCtx := filepath.Join(buildCtxDir, "test.tar")
+	if err := exec.Command("tar", "cf", buildCtx, "-C", filepath.Join(testData, "test_ctx"), ".").Run(); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name       string
+		gcsObjects map[string]string
+		config     Config
+	}{
+		{
+			name:   "EmptyConfig",
+			config: Config{},
+		},
+		{
+			name: "RunScript",
+			gcsObjects: map[string]string{
+				"/test/test.tar": buildCtx,
+			},
+			config: Config{
+				BuildContexts: map[string]string{
+					"bc": "gs://test/test.tar",
+				},
+				Steps: []struct {
+					Type string
+					Args json.RawMessage
+				}{
+					{
+						Type: "RunScript",
+						Args: []byte(`{"BuildContext": "bc", "Path": "run.sh"}`),
+					},
+					{
+						Type: "RunScript",
+						Args: []byte(`{"BuildContext": "bc", "Path": "run_env.sh", "Env": "TEST=t"}`),
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			tempDir, err := ioutil.TempDir("", "provisioner-test-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tempDir)
+			gcs := fakes.GCSForTest(t)
+			for name, path := range test.gcsObjects {
+				data, err := ioutil.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gcs.Objects[name] = data
+			}
+			deps := Deps{
+				GCSClient:           gcs.Client,
+				TarCmd:              "tar",
+				SystemctlCmd:        "/bin/true",
+				RootDir:             tempDir,
+				DockerCredentialGCR: "/bin/true",
+			}
+			stateDir := filepath.Join(tempDir, "var", "lib", ".cos-customizer")
+			funcCall := fmt.Sprintf("Run(ctx, %+v, %q, %+v)", deps, stateDir, test.config)
+			if err := Run(ctx, deps, stateDir, test.config); err != nil {
+				t.Fatalf("%s = %v; want nil", funcCall, err)
+			}
+		})
 	}
 }

--- a/src/pkg/provisioner/testdata/test_ctx/run.sh
+++ b/src/pkg/provisioner/testdata/test_ctx/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ ! -f run.sh ]]; then
+  echo "Cannot find self in working directory (PWD is incorrect)"
+  exit 1
+fi

--- a/src/pkg/provisioner/testdata/test_ctx/run_env.sh
+++ b/src/pkg/provisioner/testdata/test_ctx/run_env.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ -z "${TMPDIR}" ]]; then
+  echo "TMPDIR is missing in environment (parent env is not propagated)"
+  exit 1
+fi
+if [[ -z "${TEST}" ]]; then
+  echo "TEST is missing in environment"
+  echo "(user provided env may not be propagated)"
+  exit 1
+fi


### PR DESCRIPTION
Dependencies are mostly stubbed with /bin/true. I needed to stub mount
and unmount by replacing the definition of those functions in memory
because those functions require root permissions to run.