### PR TITLE
provisioner: Add InstallGPU step

### DIFF
--- a/src/cmd/cos_customizer/BUILD.bazel
+++ b/src/cmd/cos_customizer/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//src/pkg/gce:go_default_library",
         "//src/pkg/preloader:go_default_library",
         "//src/pkg/tools/partutil:go_default_library",
+        "//src/pkg/utils:go_default_library",
         "@com_github_google_subcommands//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@org_golang_google_api//compute/v1:go_default_library",

--- a/src/cmd/cos_customizer/install_gpu.go
+++ b/src/cmd/cos_customizer/install_gpu.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/config"
 	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/fs"
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils"
 
 	"cloud.google.com/go/storage"
 	"github.com/google/subcommands"
@@ -173,10 +174,10 @@ func (i *InstallGPU) templateScript(scriptPath string) error {
 		NvidiaInstallDirHost string
 		SetCOSDownloadGCS    string
 	}{
-		NvidiaDriverVersion:  quoteForShell(i.NvidiaDriverVersion),
-		NvidiaDriverMd5sum:   quoteForShell(i.NvidiaDriverMd5sum),
-		NvidiaInstallDirHost: quoteForShell(i.NvidiaInstallDirHost),
-		SetCOSDownloadGCS:    quoteForShell(setCOSDownloadGCS),
+		NvidiaDriverVersion:  utils.QuoteForShell(i.NvidiaDriverVersion),
+		NvidiaDriverMd5sum:   utils.QuoteForShell(i.NvidiaDriverMd5sum),
+		NvidiaInstallDirHost: utils.QuoteForShell(i.NvidiaInstallDirHost),
+		SetCOSDownloadGCS:    utils.QuoteForShell(setCOSDownloadGCS),
 	}
 	tmpl, err := template.New(filepath.Base(scriptPath)).ParseFiles(scriptPath)
 	if err != nil {

--- a/src/cmd/cos_customizer/run_script.go
+++ b/src/cmd/cos_customizer/run_script.go
@@ -22,9 +22,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/fs"
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils"
 
 	"github.com/google/subcommands"
 )
@@ -62,10 +62,6 @@ func (r *RunScript) SetFlags(f *flag.FlagSet) {
 	f.Var(r.env, "env", "Env vars to set before running the script.")
 }
 
-func quoteForShell(str string) string {
-	return fmt.Sprintf("'%s'", strings.Replace(str, "'", "'\"'\"'", -1))
-}
-
 // createEnvFile creates an environment variable file from the given map. During preloading, this file
 // is sourced before the script associated with this step is run. The resulting file is stored in
 // the builtin build context to avoid collisions with user data.
@@ -78,7 +74,7 @@ func createEnvFile(prefix string, files *fs.Files, env map[string]string) (strin
 		return "", err
 	}
 	for k, v := range env {
-		if _, err := fmt.Fprintf(envFile, "export %s=%s\n", k, quoteForShell(v)); err != nil {
+		if _, err := fmt.Fprintf(envFile, "export %s=%s\n", k, utils.QuoteForShell(v)); err != nil {
 			envFile.Close()
 			os.Remove(envFile.Name())
 			return "", err

--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -4,6 +4,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "gpu_setup_script.go",
+        "install_gpu_step.go",
         "provisioner.go",
         "run_script_step.go",
         "state.go",

--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -46,11 +46,17 @@ type Config struct {
 	//
 	// Type: InstallGPU
 	// Args:
-	// - Version: The nvidia driver version to install
-	// - MD5Sum: An optional md5 hash to use to verify the downloaded nvidia
-	//   installer
-	// - InstallDir: An absolute path to install nvidia drivers in to
-	// - GCSDownloadPrefix: A optional gs:// URI that will be used as a prefix
+	// - NvidiaDriverVersion: The nvidia driver version to install. Can also be
+	//   the name of an nvidia installer .run file. If a .run file is provided and
+	//   a GCSDepsPrefix is provided, the .run file will be fetched from the
+	//   GCSDepsPrefix location.
+	// - NvidiaDriverMD5Sum: An optional md5 hash to use to verify the downloaded nvidia
+	//   installer.
+	// - NvidiaInstallDirHost: An absolute path specifying where nvidia drivers
+	//   should be installed. Defaults to /var/lib/nvidia.
+	// - NvidiaInstallerContainer: The cos-gpu-installer container image to use
+	//   for installing nvidia drivers.
+	// - GCSDepsPrefix: A optional gs:// URI that will be used as a prefix
 	//   for downloading cos-gpu-installer dependencies.
 	//
 	// Type: AppendKernelCmdLine
@@ -71,6 +77,13 @@ func parseStep(stepType string, stepArgs json.RawMessage) (step, error) {
 	case "RunScript":
 		var s step
 		s = &runScriptStep{}
+		if err := json.Unmarshal(stepArgs, s); err != nil {
+			return nil, err
+		}
+		return s, nil
+	case "InstallGPU":
+		var s step
+		s = &installGPUStep{}
 		if err := json.Unmarshal(stepArgs, s); err != nil {
 			return nil, err
 		}

--- a/src/pkg/provisioner/gpu_setup_script.go
+++ b/src/pkg/provisioner/gpu_setup_script.go
@@ -1,0 +1,88 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+const gpuSetupScriptTemplate = `#!/bin/bash
+
+set -o errexit
+
+export NVIDIA_DRIVER_VERSION={{.NvidiaDriverVersion}}
+export NVIDIA_DRIVER_MD5SUM={{.NvidiaDriverMD5Sum}}
+export NVIDIA_INSTALL_DIR_HOST={{.NvidiaInstallDirHost}}
+export COS_NVIDIA_INSTALLER_CONTAINER={{.NvidiaInstallerContainer}}
+export NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia
+export ROOT_MOUNT_DIR=/root
+
+pull_installer() {
+  local docker_code
+  local i=1
+  while [[ $i -le 10 ]]; do
+    echo "Pulling cos-gpu-installer container image... [${i}/10]"
+    docker pull "${COS_NVIDIA_INSTALLER_CONTAINER}" && break || docker_code="$?"
+    i=$((i+1))
+    sleep 2
+  done
+  if [[ $i -eq 11 ]]; then
+    echo "Pulling cos-gpu-installer failed."
+    echo "Docker journal logs:"
+    journalctl -u docker.service --no-pager
+    exit "${docker_code}"
+  fi
+  echo "Successfully pulled cos-gpu-installer container image."
+}
+
+main() {
+  mkdir -p "${NVIDIA_INSTALL_DIR_HOST}"
+  mount --bind "${NVIDIA_INSTALL_DIR_HOST}" "${NVIDIA_INSTALL_DIR_HOST}"
+  mount -o remount,exec "${NVIDIA_INSTALL_DIR_HOST}"
+  pull_installer
+  docker_run_cmd="docker run \
+    --rm \
+    --privileged \
+    --net=host \
+    --pid=host \
+    --volume ${NVIDIA_INSTALL_DIR_HOST}:${NVIDIA_INSTALL_DIR_CONTAINER} \
+    --volume /dev:/dev \
+    --volume /:${ROOT_MOUNT_DIR} \
+    -e NVIDIA_DRIVER_VERSION \
+    -e NVIDIA_DRIVER_MD5SUM \
+    -e NVIDIA_INSTALL_DIR_HOST \
+    -e COS_NVIDIA_INSTALLER_CONTAINER \
+    -e NVIDIA_INSTALL_DIR_CONTAINER \
+    -e ROOT_MOUNT_DIR \
+    -e COS_DOWNLOAD_GCS \
+    -e GPU_INSTALLER_DOWNLOAD_URL \
+    ${COS_NVIDIA_INSTALLER_CONTAINER}"
+  if ! ${docker_run_cmd}; then
+    echo "GPU install failed."
+    if [[ -f /var/lib/nvidia/nvidia-installer.log ]]; then
+      echo "Nvidia installer debug logs:"
+      cat /var/lib/nvidia/nvidia-installer.log
+    fi
+    return 1
+  fi
+  ${NVIDIA_INSTALL_DIR_HOST}/bin/nvidia-smi
+
+  # Start nvidia-persistenced
+  if ! pgrep -f nvidia-persistenced > /dev/null; then
+    "${NVIDIA_INSTALL_DIR_HOST}/bin/nvidia-persistenced" --verbose
+  fi
+
+  # Set softlockup_panic
+  echo 1 > /proc/sys/kernel/softlockup_panic
+}
+
+main
+`

--- a/src/pkg/provisioner/install_gpu_step.go
+++ b/src/pkg/provisioner/install_gpu_step.go
@@ -1,0 +1,122 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils"
+)
+
+type installGPUStep struct {
+	NvidiaDriverVersion      string
+	NvidiaDriverMD5Sum       string
+	NvidiaInstallDirHost     string
+	NvidiaInstallerContainer string
+	GCSDepsPrefix            string
+}
+
+func (s *installGPUStep) validate() error {
+	if s.NvidiaDriverVersion == "" {
+		return errors.New("invalid args: NvidiaDriverVersion is required in InstallGPU")
+	}
+	if s.NvidiaInstallerContainer == "" {
+		return errors.New("invalid args: NvidiaInstallerContainer is required in InstallGPU")
+	}
+	return nil
+}
+
+func (s *installGPUStep) setDefaults() {
+	if s.NvidiaInstallDirHost == "" {
+		s.NvidiaInstallDirHost = "/var/lib/nvidia"
+	}
+}
+
+func (s *installGPUStep) installScript(path, driverVersion string) (err error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0744)
+	if err != nil {
+		return err
+	}
+	defer utils.CheckClose(f, fmt.Sprintf("error closing %q", path), &err)
+	t, err := template.New("gpu-script").Parse(gpuSetupScriptTemplate)
+	if err != nil {
+		return err
+	}
+	if err := t.Execute(f, &installGPUStep{
+		NvidiaDriverVersion:      utils.QuoteForShell(driverVersion),
+		NvidiaDriverMD5Sum:       utils.QuoteForShell(s.NvidiaDriverMD5Sum),
+		NvidiaInstallDirHost:     utils.QuoteForShell(s.NvidiaInstallDirHost),
+		NvidiaInstallerContainer: utils.QuoteForShell(s.NvidiaInstallerContainer),
+	}); err != nil {
+		return fmt.Errorf("error installing %q: %v", path, err)
+	}
+	return nil
+}
+
+func (s *installGPUStep) runInstaller(path string) error {
+	var downloadURL string
+	if s.GCSDepsPrefix != "" {
+		downloadURL = "https://storage.googleapis.com/" + strings.TrimPrefix(s.GCSDepsPrefix, "gs://")
+	}
+	var gpuInstallerDownloadURL string
+	if strings.HasSuffix(s.NvidiaDriverVersion, ".run") && downloadURL != "" {
+		gpuInstallerDownloadURL = downloadURL + "/" + s.NvidiaDriverVersion
+	}
+	if err := utils.RunCommand([]string{"/bin/bash", path}, "", append(os.Environ(), []string{
+		"COS_DOWNLOAD_GCS=" + downloadURL,
+		"GPU_INSTALLER_DOWNLOAD_URL=" + gpuInstallerDownloadURL,
+	}...)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *installGPUStep) run(runState *state) error {
+	if err := s.validate(); err != nil {
+		return err
+	}
+	s.setDefaults()
+	var driverVersion string
+	if strings.HasSuffix(s.NvidiaDriverVersion, ".run") {
+		// NVIDIA-Linux-x86_64-450.51.06.run -> 450.51.06
+		fields := strings.FieldsFunc(strings.TrimSuffix(s.NvidiaDriverVersion, ".run"), func(r rune) bool { return r == '-' })
+		if len(fields) != 4 {
+			return fmt.Errorf("malformed nvidia installer: %q", s.NvidiaDriverVersion)
+		}
+		driverVersion = fields[3]
+	} else {
+		driverVersion = s.NvidiaDriverVersion
+	}
+	log.Println("Installing GPU drivers...")
+	scriptPath := filepath.Join(s.NvidiaInstallDirHost, "setup_gpu.sh")
+	if err := s.installScript(scriptPath, driverVersion); err != nil {
+		return err
+	}
+	if err := s.runInstaller(scriptPath); err != nil {
+		log.Println("Installing GPU drivers failed")
+		return err
+	}
+	log.Println("Done installing GPU drivers")
+	return nil
+}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // CheckClose closes an io.Closer and checks its error. Useful for checking the
@@ -53,4 +54,9 @@ func RunCommand(args []string, dir string, env []string) error {
 		return fmt.Errorf(`error in cmd "%v", see stderr for details: %v`, args, err)
 	}
 	return nil
+}
+
+// QuoteForShell quotes a string for use in a bash shell.
+func QuoteForShell(str string) string {
+	return fmt.Sprintf("'%s'", strings.Replace(str, "'", "'\"'\"'", -1))
 }


### PR DESCRIPTION
The InstallGPU step is implemented using pretty much the same shell
script that we are already using. This is primarily because of the
requirement to install this script as part of installing GPU drivers.
It's simpler to have one script that is executed at both install time
and runtime than to have two nearly identical behaviors implemented in
different languages (Go and bash). I have considered making setup_gpu.sh
a Go program and installing that for runtime use, but implementing a
data dependency in that way seemed too complicated.