### PR TITLE
provisioner: Implement the 'resume' subcommand

### DIFF
--- a/src/cmd/provisioner/BUILD.bazel
+++ b/src/cmd/provisioner/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "main.go",
+        "resume.go",
         "run.go",
     ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/cmd/provisioner",

--- a/src/cmd/provisioner/resume.go
+++ b/src/cmd/provisioner/resume.go
@@ -1,0 +1,58 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/google/subcommands"
+
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner"
+)
+
+// Resume implements subcommands.Command for the "resume" command.
+// This command resumes provisioning from given provisioning state.
+type Resume struct{}
+
+// Name implements subcommands.Command.Name.
+func (r *Resume) Name() string {
+	return "resume"
+}
+
+// Synopsis implements subcommands.Command.Synopsis.
+func (r *Resume) Synopsis() string {
+	return "Resume provisioning from provided state."
+}
+
+// Usage implements subcommands.Command.Usage.
+func (r *Resume) Usage() string {
+	return `resume
+`
+}
+
+// SetFlags implements subcommands.Command.SetFlags.
+func (r *Resume) SetFlags(f *flag.FlagSet) {}
+
+// Execute implements subcommands.Command.Execute.
+func (r *Resume) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+	deps := args[0].(provisioner.Deps)
+	if err := provisioner.Resume(ctx, deps, *stateDir); err != nil {
+		log.Printf("Provisioning error: %v", err)
+		return subcommands.ExitFailure
+	}
+	return subcommands.ExitSuccess
+}

--- a/src/cmd/provisioner/run.go
+++ b/src/cmd/provisioner/run.go
@@ -22,9 +22,9 @@ import (
 	"io/ioutil"
 	"log"
 
-	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner"
 	"github.com/google/subcommands"
+
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner"
 )
 
 // Run implements subcommands.Command for the "run" command.
@@ -63,6 +63,7 @@ func (r *Run) validate() error {
 
 // Execute implements subcommands.Command.Execute.
 func (r *Run) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+	deps := args[0].(provisioner.Deps)
 	if err := r.validate(); err != nil {
 		log.Printf("Error in flags: %v", err)
 		return subcommands.ExitUsageError
@@ -76,18 +77,6 @@ func (r *Run) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{})
 	if err := json.Unmarshal(data, &c); err != nil {
 		log.Printf("JSON parsing error in %q: %v", r.configPath, err)
 		return subcommands.ExitFailure
-	}
-	gcsClient, err := storage.NewClient(ctx)
-	if err != nil {
-		log.Println(err)
-		return subcommands.ExitFailure
-	}
-	deps := provisioner.Deps{
-		GCSClient:           gcsClient,
-		TarCmd:              "tar",
-		SystemctlCmd:        "systemctl",
-		DockerCredentialGCR: "docker-credential-gcr",
-		RootDir:             "/",
 	}
 	if err := provisioner.Run(ctx, deps, *stateDir, c); err != nil {
 		log.Printf("Provisioning error: %v", err)

--- a/src/pkg/provisioner/state.go
+++ b/src/pkg/provisioner/state.go
@@ -49,6 +49,17 @@ func (s *state) dataPath() string {
 	return filepath.Join(s.dir, "state.json")
 }
 
+func (s *state) read() error {
+	data, err := ioutil.ReadFile(s.dataPath())
+	if err != nil {
+		return fmt.Errorf("error reading %q: %v", s.dataPath(), err)
+	}
+	if err := json.Unmarshal(data, &s.data); err != nil {
+		return fmt.Errorf("error parsing JSON file %q: %v", s.dataPath(), err)
+	}
+	return nil
+}
+
 func (s *state) write() error {
 	data, err := json.Marshal(&s.data)
 	if err != nil {
@@ -124,6 +135,14 @@ func initState(ctx context.Context, deps Deps, dir string, c Config) (*state, er
 	}
 	if err := s.unpackBuildContexts(ctx, deps); err != nil {
 		return nil, fmt.Errorf("error unpacking build contexts: %v", err)
+	}
+	return s, nil
+}
+
+func loadState(dir string) (*state, error) {
+	s := &state{dir: dir}
+	if err := s.read(); err != nil {
+		return nil, err
 	}
 	return s, nil
 }


### PR DESCRIPTION
Resume resumes an in-progress provisioning flow using the provided state
dir. This is useful for resuming provisioning after a reboot.