### PR TITLE
provisioner: Implement behavior for switching root device

### DIFF
--- a/src/cmd/provisioner/main.go
+++ b/src/cmd/provisioner/main.go
@@ -52,8 +52,14 @@ func main() {
 		TarCmd:              "tar",
 		SystemctlCmd:        "systemctl",
 		DockerCredentialGCR: "docker-credential-gcr",
+		RootdevCmd:          "rootdev",
+		CgptCmd:             "cgpt",
 		RootDir:             "/",
 	}
-	ret := int(subcommands.Execute(ctx, deps))
-	os.Exit(ret)
+	var exitCode int
+	ret := subcommands.Execute(ctx, deps, &exitCode)
+	if ret != subcommands.ExitSuccess {
+		os.Exit(int(ret))
+	}
+	os.Exit(exitCode)
 }

--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "disk_layout.go",
         "gpu_setup_script.go",
         "install_gpu_step.go",
         "provisioner.go",

--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	BootDisk struct {
 		StatefulSize string
 		OEMSize      string
-		ReclaimSDA3  string
+		ReclaimSDA3  bool
 		VerifiedOEM  bool
 	}
 	// Steps are provisioning behaviors that can be run.

--- a/src/pkg/provisioner/disk_layout.go
+++ b/src/pkg/provisioner/disk_layout.go
@@ -1,0 +1,81 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils"
+)
+
+func switchRoot(deps Deps, runState *state) (err error) {
+	if !runState.data.Config.BootDisk.ReclaimSDA3 {
+		log.Println("ReclaimSDA3 is not set, not switching root device")
+		return nil
+	}
+	sda3Device := filepath.Join(deps.RootDir, "dev", "sda3")
+	sda5Device := filepath.Join(deps.RootDir, "dev", "sda5")
+	rootDev, err := exec.Command(deps.RootdevCmd, "-s").Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("error running rootdev: %v: stderr = %q", exitErr, string(exitErr.Stderr))
+		}
+		return fmt.Errorf("error running rootdev: %v", err)
+	}
+	if strings.TrimSpace(string(rootDev)) == sda5Device {
+		log.Println("Current root device is /dev/sda5, not switching root device")
+		return nil
+	}
+	log.Println("Need to switch root device")
+	log.Println("Copying sda3 to sda5...")
+	in, err := os.Open(sda3Device)
+	if err != nil {
+		return err
+	}
+	defer utils.CheckClose(in, "error closing /dev/sda3", &err)
+	out, err := os.Create(sda5Device)
+	if err != nil {
+		return err
+	}
+	defer utils.CheckClose(out, "error closing /dev/sda5", &err)
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("error copying from sda3 to sda5: %v", err)
+	}
+	log.Println("Setting GPT priority...")
+	device := filepath.Join(deps.RootDir, "dev", "sda")
+	if err := utils.RunCommand([]string{deps.CgptCmd, "prioritize", "-P", "5", "-i", "4", device}, "", nil); err != nil {
+		return err
+	}
+	log.Println("Reboot required to switch root device")
+	return ErrRebootRequired
+}
+
+// repartitionBootDisk executes all behaviors related to repartitioning the boot
+// disk. Most of these behaviors require a reboot. To keep reboots simple (e.g.
+// we don't want to initiate a reboot when deferred statements are unresolved),
+// we handle reboots by returning ErrRebootRequired and asking the caller to
+// initiate the reboot.
+func repartitionBootDisk(deps Deps, runState *state) error {
+	if err := switchRoot(deps, runState); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
COS Customizer currently offers repartitioning features that are
controlled through the disk size and OEM size options. Some of these
features depend on rebooting into COS's secondary update slot; in
particular, reclaiming disk space by disabling auto updates requires
that the system reboot into the secondary update slot. This change
implements behavior for rebooting into the secondary update slot. The
behavior is implemented in pretty much the same way it is implemented in
startup.sh. The biggest difference with startup.sh is how reboots are
handled.

In startup.sh, reboots are done in place as soon as the reboot is
identified as necessary. This introduced a few problems:
- There is a race between startup.sh and when startup.sh is killed
- trap statements sometimes execute
A few hacks were put in place in startup.sh to work around these
problems. This change addresses these problems by propagating reboot
requests to the user, through ErrRebootRequired. The user needs
to issue the reboot whenever they are ready for it.

In the specific context of COS Customizer, the user that needs to issue
the reboot will be a much thinner startup.sh. That script will focus
purely on dealing with run/resume/reboot semantics, and won't need to
worry about other provisioning details.