### PR TITLE
provisioner: Implement functionality for shrinking sda3

### DIFF
--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/pkg/tools/partutil:go_default_library",
         "//src/pkg/utils:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",


### PR DESCRIPTION
COS Customizer offers functionality for reclaiming /dev/sda3 space; it
does this by rebooting into sda5, minimizing the size of /dev/sda3, and
relocating other partitions to use that space. This change adds
functionality for minimizing the size of /dev/sda3.

The core of this behavior is already implemented in
partutil.MinimizePartition. Some small refactoring was needed to make
behavior that checks if a partition is already minimal available to the
provisioner.

./run_tests passes.