### PR TITLE
provisioner: Implement behavior for relocating partitions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -130,7 +130,7 @@ container_image(
 go_image(
     name = "cos_customizer",
     base = ":cos_customizer_base",
-    embed = ["//src/cmd/cos_customizer"],
+    embed = ["//src/cmd/cos_customizer:go_default_library"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,19 +17,20 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "2d536797707dd1697441876b2e862c58839f975c8fc2f0f96636cbd428f45866",
+    sha256 = "355d40d12749d843cfd05e14c304ac053ae82be4cd257efaf5ef8ce2caf31f1c",
+    strip_prefix = "rules_go-197699822e081dad064835a09825448a3e4cc2a2",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.23.5/rules_go-v0.23.5.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.23.5/rules_go-v0.23.5.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/archive/197699822e081dad064835a09825448a3e4cc2a2.tar.gz",
+        "https://github.com/bazelbuild/rules_go/archive/197699822e081dad064835a09825448a3e4cc2a2.tar.gz",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d",
+    sha256 = "222e49f034ca7a1d1231422cdb67066b885819885c356673cb1f72f748a3c9d4",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz",
     ],
 )
 
@@ -69,7 +70,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_to
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(version="1.16")
 
 rules_pkg_dependencies()
 

--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -1,4 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//extras:embed_data.bzl", "go_embed_data")
+
+# Our goal is for this program to be embedded into this Go package. Go embed
+# only allows files in the same package directory to be embedded. So we need to
+# use a "no-op" genrule to place this binary in the same directory as the
+# package source.
+genrule(
+    name = "handle_disk_layout.bin",
+    srcs = ["//src/cmd/handle_disk_layout:handle_disk_layout_bin"],
+    outs = ["_handle_disk_layout.bin"],
+    cmd = "cp $< $@",
+)
 
 go_library(
     name = "go_default_library",
@@ -11,6 +23,9 @@ go_library(
         "run_script_step.go",
         "state.go",
         "systemd.go",
+    ],
+    embedsrcs = [
+        ":handle_disk_layout.bin",
     ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner",
     visibility = ["//visibility:public"],

--- a/src/pkg/provisioner/disk_layout.go
+++ b/src/pkg/provisioner/disk_layout.go
@@ -15,17 +15,24 @@
 package provisioner
 
 import (
+	_ "embed"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/tools/partutil"
 	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils"
 )
+
+//go:embed _handle_disk_layout.bin
+var handleDiskLayoutBin []byte
 
 func switchRoot(deps Deps, runState *state) (err error) {
 	if !runState.data.Config.BootDisk.ReclaimSDA3 {
@@ -91,6 +98,100 @@ func shrinkSDA3(deps Deps, runState *state) error {
 	return ErrRebootRequired
 }
 
+func setupOnShutdownUnit(deps Deps, runState *state) (err error) {
+	if err := mountFunc("", filepath.Join(deps.RootDir, "tmp"), "", unix.MS_REMOUNT|unix.MS_NOSUID|unix.MS_NODEV, ""); err != nil {
+		return fmt.Errorf("error remounting /tmp as exec: %v", err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(deps.RootDir, "tmp", "handle_disk_layout.bin"), handleDiskLayoutBin, 0744); err != nil {
+		return err
+	}
+	data := fmt.Sprintf(`[Unit]
+Description=Run after everything unmounted
+DefaultDependencies=false
+Conflicts=shutdown.target
+Before=mnt-stateful_partition.mount usr-share-oem.mount
+After=tmp.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/bin/true
+ExecStop=/bin/bash -c '/tmp/handle_disk_layout.bin /dev/sda 1 8 "%s" "%t" 2>&1 | sed "s/^/BuildStatus: "'
+TimeoutStopSec=600
+StandardOutput=tty
+StandardError=tty
+TTYPath=/dev/ttyS2
+`, runState.data.Config.BootDisk.OEMSize, runState.data.Config.BootDisk.ReclaimSDA3)
+	if err := ioutil.WriteFile(filepath.Join(deps.RootDir, "etc/systemd/system/last-run.service"), []byte(data), 0664); err != nil {
+		return err
+	}
+	systemd := systemdClient{systemctl: deps.SystemctlCmd}
+	if err := systemd.start("last-run.service", []string{"--no-block"}); err != nil {
+		return err
+	}
+	// journald needs to be stopped in order for the stateful partition to be
+	// unmounted at shutdown. We need the stateful partition to be unmounted so
+	// that disk repartitioning can occur.
+	if err := systemd.stopJournald(deps.RootDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func relocatePartitions(deps Deps, runState *state) error {
+	if !runState.data.Config.BootDisk.ReclaimSDA3 && runState.data.Config.BootDisk.OEMSize == "" {
+		log.Println("ReclaimSDA3 is not set, OEM resize not requested, not relocating partitions")
+		return nil
+	}
+	device := filepath.Join(deps.RootDir, "dev", "sda")
+	sda3Start, err := partutil.ReadPartitionStart(device, 3)
+	if err != nil {
+		return err
+	}
+	sda3Size, err := partutil.ReadPartitionSize(device, 3)
+	if err != nil {
+		return err
+	}
+	sda3End := sda3Start + sda3Size - 1
+	if runState.data.Config.BootDisk.OEMSize != "" {
+		// Check if OEM partition is after sda3; if so, then we're done
+		oemStart, err := partutil.ReadPartitionStart(device, 8)
+		if err != nil {
+			return err
+		}
+		if oemStart > sda3End {
+			log.Println("OEM resize requested, OEM appears to be relocated after sda3. Partition relocation is complete")
+			return nil
+		}
+	} else {
+		// Check two things:
+		// 1. sda3 is minimal
+		// 2. Stateful partition is located after sda3
+		//
+		// If both are true, we are done.
+		minimal, err := partutil.IsPartitionMinimal(device, 3)
+		if err != nil {
+			return err
+		}
+		statefulStart, err := partutil.ReadPartitionStart(device, 1)
+		if err != nil {
+			return err
+		}
+		if minimal && statefulStart == sda3End+1 {
+			log.Println("ReclaimSDA3 is set, sda3 appears to have been reclaimed. Partition relocation is complete")
+			return nil
+		}
+	}
+	// Partition relocation must be done. Prepare for disk relocation to happen on
+	// the next reboot
+	log.Println("Partition relocation is required. Preparing for partition relocation to occur on the next reboot")
+	if err := setupOnShutdownUnit(deps, runState); err != nil {
+		return err
+	}
+	log.Println("Reboot required to relocate partitions")
+	return ErrRebootRequired
+}
+
 // repartitionBootDisk executes all behaviors related to repartitioning the boot
 // disk. Most of these behaviors require a reboot. To keep reboots simple (e.g.
 // we don't want to initiate a reboot when deferred statements are unresolved),
@@ -101,6 +202,9 @@ func repartitionBootDisk(deps Deps, runState *state) error {
 		return err
 	}
 	if err := shrinkSDA3(deps, runState); err != nil {
+		return err
+	}
+	if err := relocatePartitions(deps, runState); err != nil {
 		return err
 	}
 	return nil

--- a/src/pkg/provisioner/systemd.go
+++ b/src/pkg/provisioner/systemd.go
@@ -15,8 +15,11 @@
 package provisioner
 
 import (
+	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils"
 )
@@ -29,6 +32,14 @@ func (sc *systemdClient) isActive(unit string) bool {
 	return exec.Command(sc.systemctl, "is-active", unit).Run() == nil
 }
 
+func (sc *systemdClient) reload() error {
+	return utils.RunCommand([]string{sc.systemctl, "daemon-reload"}, "", nil)
+}
+
+func (sc *systemdClient) start(unit string, flags []string) error {
+	return utils.RunCommand(append([]string{sc.systemctl, "start", unit}, flags...), "", nil)
+}
+
 func (sc *systemdClient) stop(unit string) error {
 	if sc.isActive(unit) {
 		log.Printf("%q is active, stopping...", unit)
@@ -38,6 +49,35 @@ func (sc *systemdClient) stop(unit string) error {
 		log.Printf("%q stopped", unit)
 	} else {
 		log.Printf("%q is not active, ignoring", unit)
+	}
+	return nil
+}
+
+func (sc *systemdClient) stopJournald(rootDir string) error {
+	configDirName := filepath.Join(rootDir, "etc/systemd/system/systemd-journald.service.d")
+	configName := filepath.Join(configDirName, "override.conf")
+	configData := `[Service]
+Restart=no
+`
+	if err := os.MkdirAll(configDirName, 0755); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(configName, []byte(configData), 0644); err != nil {
+		return err
+	}
+	if err := sc.reload(); err != nil {
+		return err
+	}
+	for _, u := range []string{
+		"systemd-journald.socket",
+		"systemd-journald-dev-log.socket",
+		"systemd-journald-audit.socket",
+		"syslog.socket",
+		"systemd-journald.service",
+	} {
+		if err := sc.stop(u); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This behavior is implemented in the same way as startup.sh. We install a
systemd unit to run at shutdown time, after relevant partitions are
unmounted. This unit relocates partitions according to requirements.

Similar to startup.sh, we use the handle_disk_layout.bin program to
repartition the boot disk. We embed this program into the Go package
using Go 1.16's new embed behavior to distribute handle_disk_layout.bin
statically with the provisioner program. This makes deployment much
easier.

To use Go's embed behavior, I needed to upgrade our Go version to 1.16,
so I did that in the WORKSPACE file.

./run_tests.sh passes.