### PR TITLE
provisioner: Implement behavior for resizing the OEM fs

### DIFF
--- a/src/cmd/provisioner/main.go
+++ b/src/cmd/provisioner/main.go
@@ -54,6 +54,8 @@ func main() {
 		DockerCredentialGCR: "docker-credential-gcr",
 		RootdevCmd:          "rootdev",
 		CgptCmd:             "cgpt",
+		Resize2fsCmd:        "resize2fs",
+		E2fsckCmd:           "e2fsck",
 		RootDir:             "/",
 	}
 	var exitCode int

--- a/src/pkg/provisioner/provisioner.go
+++ b/src/pkg/provisioner/provisioner.go
@@ -193,6 +193,10 @@ type Deps struct {
 	RootdevCmd string
 	// CgptCmd is the path to the cgpt binary.
 	CgptCmd string
+	// Resize2fsCmd is the path to the resize2fs binary.
+	Resize2fsCmd string
+	// E2fsckCmd is the path to the e2fsck binary.
+	E2fsckCmd string
 	// RootDir is the path to the root file system. Should be "/" in all real
 	// runtime situations.
 	RootDir string


### PR DESCRIPTION
After the OEM partition is resized, the file system needs to be resized.
We can resize using resize2fs, like in startup.sh.

We do not implement resizing to a size smaller than the full partition
yet. We will implement that when we add the seal OEM partition step.