### PR TITLE
provisioner: Add WaitForDiskResize functionality

### DIFF
--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -29,10 +29,9 @@ type Config struct {
 	BuildContexts map[string]string
 	// BootDisk defines how the boot disk should be configured.
 	BootDisk struct {
-		StatefulSize string
-		OEMSize      string
-		ReclaimSDA3  bool
-		VerifiedOEM  bool
+		OEMSize           string
+		ReclaimSDA3       bool
+		WaitForDiskResize bool
 	}
 	// Steps are provisioning behaviors that can be run.
 	// The supported provisioning behaviors are:

--- a/src/pkg/provisioner/state.go
+++ b/src/pkg/provisioner/state.go
@@ -36,8 +36,9 @@ var (
 )
 
 type stateData struct {
-	Config      Config
-	CurrentStep int
+	Config             Config
+	CurrentStep        int
+	DiskResizeComplete bool
 }
 
 type state struct {


### PR DESCRIPTION
When repartitioning the disk, it is useful to enable arbitrary large
disk sizes. However, disk resize needs to occur at a specific time in
the repartitioning process to avoid partition relocation taking an
extremely long time. startup.sh currently handles this by expecting disk
resizing to occur during "wait_daisy_logging", which waits for a file to
exist in GCS. We handle it more intelligently here by waiting for the
disk to actually change in size.