### PR TITLE
provisioner: Add DisableAutoUpdates step

### DIFF
--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "disable_auto_update_step.go",
         "disk_layout.go",
         "gpu_setup_script.go",
         "install_gpu_step.go",
@@ -30,6 +31,7 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner",
     visibility = ["//visibility:public"],
     deps = [
+        "//src/pkg/tools:go_default_library",
         "//src/pkg/tools/partutil:go_default_library",
         "//src/pkg/utils:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",

--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -58,9 +58,8 @@ type Config struct {
 	// - GCSDepsPrefix: A optional gs:// URI that will be used as a prefix
 	//   for downloading cos-gpu-installer dependencies.
 	//
-	// Type: AppendKernelCmdLine
-	// Args:
-	// - Value: The exact text to append to the kernel command line.
+	// Type: DisableAutoUpdate
+	// Args: This step takes no arguments.
 	Steps []struct {
 		Type string
 		Args json.RawMessage
@@ -87,6 +86,8 @@ func parseStep(stepType string, stepArgs json.RawMessage) (step, error) {
 			return nil, err
 		}
 		return s, nil
+	case "DisableAutoUpdate":
+		return &disableAutoUpdateStep{}, nil
 	default:
 		return nil, fmt.Errorf("unknown step type: %q", stepType)
 	}

--- a/src/pkg/provisioner/disable_auto_update_step.go
+++ b/src/pkg/provisioner/disable_auto_update_step.go
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	"log"
+
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/tools"
+)
+
+type disableAutoUpdateStep struct{}
+
+func (s *disableAutoUpdateStep) run(runState *state) error {
+	log.Println("Disabling auto updates")
+	if err := tools.DisableSystemdService("update-engine.service"); err != nil {
+		return err
+	}
+	log.Println("Done disabling auto updates")
+	return nil
+}


### PR DESCRIPTION
This is implemented in the same way as before, by updating the kernel
command line to mask update-engine.service.