### PR TITLE
provisioner: Add SealOEM step

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -78,6 +78,7 @@ container_image(
         packages["libm17n-0"],
         packages["libgpg-error0"],
     ],
+    visibility = ["//visibility:public"],
 )
 
 genrule(

--- a/src/cmd/seal_oem/seal_oem_bin.go
+++ b/src/cmd/seal_oem/seal_oem_bin.go
@@ -34,7 +34,7 @@ func main() {
 	if err != nil {
 		log.Fatalln("error: the argument oemFSSize4K must be an uint64")
 	}
-	if err := tools.SealOEMPartition(oemFSSize4K); err != nil {
+	if err := tools.SealOEMPartition("./veritysetup.img", oemFSSize4K); err != nil {
 		log.Fatalln(err.Error())
 	}
 }

--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -12,6 +12,13 @@ genrule(
     cmd = "cp $< $@",
 )
 
+genrule(
+    name = "veritysetup.img",
+    srcs = ["//:veritysetup.tar"],
+    outs = ["_veritysetup.img"],
+    cmd = "cp $< $@",
+)
+
 go_library(
     name = "go_default_library",
     srcs = [
@@ -22,11 +29,13 @@ go_library(
         "install_gpu_step.go",
         "provisioner.go",
         "run_script_step.go",
+        "seal_oem_step.go",
         "state.go",
         "systemd.go",
     ],
     embedsrcs = [
         ":handle_disk_layout.bin",
+        ":veritysetup.img",
     ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner",
     visibility = ["//visibility:public"],

--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	// BootDisk defines how the boot disk should be configured.
 	BootDisk struct {
 		OEMSize           string
+		OEMFSSize4K       uint64
 		ReclaimSDA3       bool
 		WaitForDiskResize bool
 	}
@@ -60,6 +61,9 @@ type Config struct {
 	//
 	// Type: DisableAutoUpdate
 	// Args: This step takes no arguments.
+	//
+	// Type: SealOEM
+	// Args: This step takes no arguments.
 	Steps []struct {
 		Type string
 		Args json.RawMessage
@@ -88,6 +92,8 @@ func parseStep(stepType string, stepArgs json.RawMessage) (step, error) {
 		return s, nil
 	case "DisableAutoUpdate":
 		return &disableAutoUpdateStep{}, nil
+	case "SealOEM":
+		return &sealOEMStep{}, nil
 	default:
 		return nil, fmt.Errorf("unknown step type: %q", stepType)
 	}

--- a/src/pkg/provisioner/seal_oem_step.go
+++ b/src/pkg/provisioner/seal_oem_step.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	_ "embed"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/tools"
+)
+
+//go:embed _veritysetup.img
+var veritysetupImg []byte
+
+type sealOEMStep struct{}
+
+func (s *sealOEMStep) run(runState *state) error {
+	log.Println("Sealing the OEM partition with dm-verity")
+	veritysetupImgPath := filepath.Join(runState.dir, "veritysetup.img")
+	if _, err := os.Stat(veritysetupImgPath); os.IsNotExist(err) {
+		if err := ioutil.WriteFile(veritysetupImgPath, veritysetupImg, 0644); err != nil {
+			return err
+		}
+	}
+	if err := tools.SealOEMPartition(veritysetupImgPath, runState.data.Config.BootDisk.OEMFSSize4K); err != nil {
+		return err
+	}
+	if err := tools.DisableSystemdService("update-engine.service"); err != nil {
+		return err
+	}
+	if err := tools.DisableSystemdService("usr-share-oem.mount"); err != nil {
+		return err
+	}
+	log.Println("Done sealing the OEM partition with dm-verity")
+	return nil
+}

--- a/src/pkg/tools/seal_oem_partition.go
+++ b/src/pkg/tools/seal_oem_partition.go
@@ -30,9 +30,8 @@ import (
 // SealOEMPartition sets the hashtree of the OEM partition
 // with "veritysetup" and modifies the kernel command line to
 // verify the OEM partition at boot time.
-func SealOEMPartition(oemFSSize4K uint64) error {
+func SealOEMPartition(veritysetupImgPath string, oemFSSize4K uint64) error {
 	const devName = "oemroot"
-	const veritysetupImgPath = "./veritysetup.img"
 	imageID, err := loadVeritysetupImage(veritysetupImgPath)
 	if err != nil {
 		return fmt.Errorf("cannot load veritysetup image at %q, error msg:(%v)", veritysetupImgPath, err)


### PR DESCRIPTION
This step seals the OEM partition using dm-verity. The veritysetup
container image is embedded statically into the Go package. Everything
else is roughly the same as the present bash implementation.