### PR TITLE
start_image_build: Create the provisioner config

### DIFF
--- a/src/cmd/cos_customizer/BUILD.bazel
+++ b/src/cmd/cos_customizer/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//src/pkg/preloader:go_default_library",
         "//src/pkg/tools/partutil:go_default_library",
         "//src/pkg/utils:go_default_library",
+        "//src/pkg/provisioner:go_default_library",
         "@com_github_google_subcommands//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@org_golang_google_api//compute/v1:go_default_library",

--- a/src/cmd/cos_customizer/disable_auto_update.go
+++ b/src/cmd/cos_customizer/disable_auto_update.go
@@ -68,7 +68,7 @@ func (d *DisableAutoUpdate) Execute(_ context.Context, f *flag.FlagSet, args ...
 		return subcommands.ExitUsageError
 	}
 	buildConfig.ReclaimSDA3 = true
-	if err := config.SaveBuildConfigToFile(configFile, buildConfig); err != nil {
+	if err := config.SaveConfigToFile(configFile, buildConfig); err != nil {
 		log.Println(err)
 		return subcommands.ExitFailure
 	}

--- a/src/cmd/cos_customizer/finish_image_build_test.go
+++ b/src/cmd/cos_customizer/finish_image_build_test.go
@@ -91,7 +91,7 @@ func setupFinishBuildFiles() (string, *fs.Files, error) {
 		os.RemoveAll(tmpDir)
 		return "", nil, err
 	}
-	if err := config.SaveBuildConfigToFile(buildConfigFile, &config.Build{GCSBucket: "b", GCSDir: "d"}); err != nil {
+	if err := config.SaveConfigToFile(buildConfigFile, &config.Build{GCSBucket: "b", GCSDir: "d"}); err != nil {
 		buildConfigFile.Close()
 		os.RemoveAll(tmpDir)
 		return "", nil, err

--- a/src/cmd/cos_customizer/install_gpu.go
+++ b/src/cmd/cos_customizer/install_gpu.go
@@ -216,7 +216,7 @@ func (i *InstallGPU) updateBuildConfig(configPath string) error {
 	if _, err := configFile.Seek(0, 0); err != nil {
 		return err
 	}
-	return config.SaveBuildConfigToFile(configFile, buildConfig)
+	return config.SaveConfigToFile(configFile, buildConfig)
 }
 
 // Execute implements subcommands.Command.Execute. It configures the current image build process to

--- a/src/cmd/cos_customizer/seal_oem.go
+++ b/src/cmd/cos_customizer/seal_oem.go
@@ -72,7 +72,7 @@ func (s *SealOEM) Execute(_ context.Context, f *flag.FlagSet, args ...interface{
 	}
 	buildConfig.SealOEM = true
 	buildConfig.ReclaimSDA3 = true
-	if err := config.SaveBuildConfigToFile(configFile, buildConfig); err != nil {
+	if err := config.SaveConfigToFile(configFile, buildConfig); err != nil {
 		log.Println(err)
 		return subcommands.ExitFailure
 	}

--- a/src/pkg/config/BUILD.bazel
+++ b/src/pkg/config/BUILD.bazel
@@ -19,7 +19,10 @@ go_library(
     srcs = ["config.go"],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/config",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_google_api//compute/v1:go_default_library"],
+    deps = [
+        "@org_golang_google_api//compute/v1:go_default_library",
+        "//src/pkg/utils:go_default_library",
+    ],
 )
 
 go_test(

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -75,16 +75,17 @@ type Build struct {
 	GCSFiles    []string
 }
 
-// SaveBuildConfigToFile clears the build config file and then saves the new config.Build.
-func SaveBuildConfigToFile(configFile *os.File, buildConfig *Build) error {
+// SaveConfigToFile clears the target config file and then saves the new config
+// data.
+func SaveConfigToFile(configFile *os.File, v interface{}) error {
 	if _, err := configFile.Seek(0, 0); err != nil {
-		return fmt.Errorf("cannot seek build config file, error msg:(%v)", err)
+		return fmt.Errorf("cannot seek config file, error msg:(%v)", err)
 	}
 	if err := configFile.Truncate(0); err != nil {
-		return fmt.Errorf("cannot truncate build config file, error msg:(%v)", err)
+		return fmt.Errorf("cannot truncate config file, error msg:(%v)", err)
 	}
-	if err := Save(configFile, buildConfig); err != nil {
-		return fmt.Errorf("cannot save build config file, error msg:(%v)", err)
+	if err := Save(configFile, v); err != nil {
+		return fmt.Errorf("cannot save config file, error msg:(%v)", err)
 	}
 	return nil
 }

--- a/src/pkg/fs/file_system.go
+++ b/src/pkg/fs/file_system.go
@@ -39,6 +39,7 @@ const (
 	stateFile                  = "state_file"
 	sourceImageConfig          = "config/source_image"
 	buildConfig                = "config/build"
+	provConfig                 = "config/provisioner"
 
 	// Volatile files. These paths exist in the volatileDir at container start time.
 	// Changes to these files do not persist across build steps.
@@ -70,6 +71,9 @@ type Files struct {
 	SourceImageConfig string
 	// BuildConfig points to the image build process configuration.
 	BuildConfig string
+	// ProvConfig points to the provisioner configuration that runs on the preload
+	// VM.
+	ProvConfig string
 	// DaisyWorkflow points to the Daisy workflow to template and use for preloading.
 	DaisyWorkflow string
 	// StartupScript points to the startup script that needs to run on the preload VM.
@@ -88,18 +92,19 @@ type Files struct {
 func DefaultFiles(persistentDir string) *Files {
 	persistentDir = filepath.Join(os.Getenv("HOME"), persistentDir)
 	return &Files{
-		persistentDir,
-		filepath.Join(persistentDir, userBuildContextArchive),
-		filepath.Join(persistentDir, builtinBuildContextArchive),
-		filepath.Join(persistentDir, builtinBuildContext),
-		filepath.Join(persistentDir, stateFile),
-		filepath.Join(persistentDir, sourceImageConfig),
-		filepath.Join(persistentDir, buildConfig),
-		filepath.Join(volatileDir, daisyWorkflow),
-		filepath.Join(volatileDir, startupScript),
-		filepath.Join(volatileDir, systemdService),
-		filepath.Join(volatileDir, builtinBuildContext),
-		daisyBin,
+		persistentDir:               persistentDir,
+		UserBuildContextArchive:     filepath.Join(persistentDir, userBuildContextArchive),
+		BuiltinBuildContextArchive:  filepath.Join(persistentDir, builtinBuildContextArchive),
+		PersistBuiltinBuildContext:  filepath.Join(persistentDir, builtinBuildContext),
+		StateFile:                   filepath.Join(persistentDir, stateFile),
+		SourceImageConfig:           filepath.Join(persistentDir, sourceImageConfig),
+		BuildConfig:                 filepath.Join(persistentDir, buildConfig),
+		ProvConfig:                  filepath.Join(persistentDir, provConfig),
+		DaisyWorkflow:               filepath.Join(volatileDir, daisyWorkflow),
+		StartupScript:               filepath.Join(volatileDir, startupScript),
+		SystemdService:              filepath.Join(volatileDir, systemdService),
+		VolatileBuiltinBuildContext: filepath.Join(volatileDir, builtinBuildContext),
+		DaisyBin:                    daisyBin,
 	}
 }
 


### PR DESCRIPTION
COS Customizer will utilize the provisioner tool by constructing a
provisioner config. To gradually and incrementally integrate the
provisioner, we will first introduce all of the logic to maintain
the provisioner config across all of the COS Customizer build steps,
and only after that remove other state that will be replaced by the
provisioner configuration (like the state file).

./run_tests passes.