### PR TITLE
run_script: Update provisioner config

### DIFF
--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils"
 	compute "google.golang.org/api/compute/v1"
 )
 
@@ -90,6 +91,17 @@ func SaveConfigToFile(configFile *os.File, v interface{}) error {
 	return nil
 }
 
+// SaveConfigToPath does the same thing as SaveConfigToFile, but updates a file
+// system path.
+func SaveConfigToPath(configPath string, config interface{}) (err error) {
+	configFile, err := os.OpenFile(configPath, os.O_RDWR, 0666)
+	if err != nil {
+		return err
+	}
+	defer utils.CheckClose(configFile, "error writing to "+configPath, &err)
+	return SaveConfigToFile(configFile, config)
+}
+
 // Save serializes the given struct as JSON and writes it out.
 func Save(w io.Writer, v interface{}) error {
 	data, err := json.Marshal(v)
@@ -110,10 +122,11 @@ func Load(r io.Reader, v interface{}) error {
 }
 
 // LoadFromFile loads JSON data from a file into the given struct.
-func LoadFromFile(path string, v interface{}) error {
+func LoadFromFile(path string, v interface{}) (err error) {
 	r, err := os.Open(path)
 	if err != nil {
 		return err
 	}
+	defer utils.CheckClose(r, fmt.Sprintf("error closing %q", path), &err)
 	return Load(r, v)
 }

--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -19,6 +19,11 @@ import (
 	"fmt"
 )
 
+type StepConfig struct {
+	Type string
+	Args json.RawMessage
+}
+
 // Config defines a provisioning flow.
 type Config struct {
 	// BuildContexts identifies the build contexts that should be used during
@@ -64,10 +69,7 @@ type Config struct {
 	//
 	// Type: SealOEM
 	// Args: This step takes no arguments.
-	Steps []struct {
-		Type string
-		Args json.RawMessage
-	}
+	Steps []StepConfig
 }
 
 type step interface {
@@ -78,7 +80,7 @@ func parseStep(stepType string, stepArgs json.RawMessage) (step, error) {
 	switch stepType {
 	case "RunScript":
 		var s step
-		s = &runScriptStep{}
+		s = &RunScriptStep{}
 		if err := json.Unmarshal(stepArgs, s); err != nil {
 			return nil, err
 		}

--- a/src/pkg/provisioner/provisioner_test.go
+++ b/src/pkg/provisioner/provisioner_test.go
@@ -16,7 +16,6 @@ package provisioner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -82,10 +81,7 @@ func TestRunInvalidArgs(t *testing.T) {
 		{
 			name: "RunScript",
 			config: Config{
-				Steps: []struct {
-					Type string
-					Args json.RawMessage
-				}{
+				Steps: []StepConfig{
 					{
 						Type: "RunScript",
 						Args: []byte("{}"),
@@ -148,10 +144,7 @@ func TestRunFailure(t *testing.T) {
 				BuildContexts: map[string]string{
 					"bc": "gs://test/test.tar",
 				},
-				Steps: []struct {
-					Type string
-					Args json.RawMessage
-				}{
+				Steps: []StepConfig{
 					{
 						Type: "RunScript",
 						Args: []byte(`{"BuildContext": "bc", "Path": "run_env.sh"}`),
@@ -225,10 +218,7 @@ func TestRunSuccess(t *testing.T) {
 				BuildContexts: map[string]string{
 					"bc": "gs://test/test.tar",
 				},
-				Steps: []struct {
-					Type string
-					Args json.RawMessage
-				}{
+				Steps: []StepConfig{
 					{
 						Type: "RunScript",
 						Args: []byte(`{"BuildContext": "bc", "Path": "run.sh"}`),

--- a/src/pkg/provisioner/run_script_step.go
+++ b/src/pkg/provisioner/run_script_step.go
@@ -24,13 +24,13 @@ import (
 	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils"
 )
 
-type runScriptStep struct {
+type RunScriptStep struct {
 	BuildContext string
 	Path         string
 	Env          string
 }
 
-func (s *runScriptStep) validate() error {
+func (s *RunScriptStep) validate() error {
 	if s.BuildContext == "" {
 		return errors.New("invalid args: BuildContext is required in RunScript")
 	}
@@ -40,7 +40,7 @@ func (s *runScriptStep) validate() error {
 	return nil
 }
 
-func (s *runScriptStep) run(runState *state) error {
+func (s *RunScriptStep) run(runState *state) error {
 	if err := s.validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
The run_script step needs to update the provisioner config with the
provisioner's RunScript step.

As part of this change, I exported the RunScriptStep struct. This
simplifies the API between COS Customizer and the provisioner. In future
changes, I will make the structs for the rest of the provisioner steps
public as well.

./run_tests passes.