### PR TITLE
disable_auto_update: Update provisioner config

### DIFF
--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -93,7 +93,7 @@ func parseStep(stepType string, stepArgs json.RawMessage) (step, error) {
 		}
 		return s, nil
 	case "DisableAutoUpdate":
-		return &disableAutoUpdateStep{}, nil
+		return &DisableAutoUpdateStep{}, nil
 	case "SealOEM":
 		return &sealOEMStep{}, nil
 	default:

--- a/src/pkg/provisioner/disable_auto_update_step.go
+++ b/src/pkg/provisioner/disable_auto_update_step.go
@@ -20,9 +20,9 @@ import (
 	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/tools"
 )
 
-type disableAutoUpdateStep struct{}
+type DisableAutoUpdateStep struct{}
 
-func (s *disableAutoUpdateStep) run(runState *state) error {
+func (s *DisableAutoUpdateStep) run(runState *state) error {
 	log.Println("Disabling auto updates")
 	if err := tools.DisableSystemdService("update-engine.service"); err != nil {
 		return err


### PR DESCRIPTION
We need to update the provisioner config in the disable_auto_update
step.

./run_tests passes.