### PR TITLE
seal_oem: Update provisioner config

### DIFF
--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -95,7 +95,7 @@ func parseStep(stepType string, stepArgs json.RawMessage) (step, error) {
 	case "DisableAutoUpdate":
 		return &DisableAutoUpdateStep{}, nil
 	case "SealOEM":
-		return &sealOEMStep{}, nil
+		return &SealOEMStep{}, nil
 	default:
 		return nil, fmt.Errorf("unknown step type: %q", stepType)
 	}

--- a/src/pkg/provisioner/seal_oem_step.go
+++ b/src/pkg/provisioner/seal_oem_step.go
@@ -27,9 +27,9 @@ import (
 //go:embed _veritysetup.img
 var veritysetupImg []byte
 
-type sealOEMStep struct{}
+type SealOEMStep struct{}
 
-func (s *sealOEMStep) run(runState *state) error {
+func (s *SealOEMStep) run(runState *state) error {
 	log.Println("Sealing the OEM partition with dm-verity")
 	veritysetupImgPath := filepath.Join(runState.dir, "veritysetup.img")
 	if _, err := os.Stat(veritysetupImgPath); os.IsNotExist(err) {


### PR DESCRIPTION
We need to update the provisioner config as part of the SealOEM step.

./run_tests passes.