### PR TITLE
preloader: Add genrule for the "cidata" image

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -117,6 +117,7 @@ container_image(
         packages["libc6"],
         packages["libselinux1"],
         packages["libpcre3"],
+        packages["mtools"],
     ],
     files = [
         ":workspace_dir",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,6 +54,13 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.2.6-1/rules_pkg-0.2.6.tar.gz"],
 )
 
+http_archive(
+    name = "rules_foreign_cc",
+    sha256 = "ab805b9e00747ba9b184790cbe2d4d19b672770fcac437f01d8c101ae60df996",
+    strip_prefix = "rules_foreign_cc-c309ec13192f69a46aaaba39587c3d7ff684eb35",
+    urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/c309ec13192f69a46aaaba39587c3d7ff684eb35.zip"],
+)
+
 git_repository(
     name = "com_google_protobuf",
     commit = "31ebe2ac71400344a5db91ffc13c4ddfb7589f92",
@@ -156,6 +163,7 @@ dpkg_list(
         "libpthread-stubs0-dev",
         "libm17n-0",
         "libgpg-error0",
+        "mtools",
     ],
     sources = [
         "@debian_stretch//file:Packages.json",
@@ -166,3 +174,12 @@ load("//:deps.bzl", "go_mod_deps")
 
 # gazelle:repository_macro deps.bzl%go_mod_deps
 go_mod_deps()
+
+load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+rules_foreign_cc_dependencies()
+
+load("//src/third_party/dosfstools:dosfstools_repositories.bzl", "dosfstools_repositories")
+dosfstools_repositories()
+
+load("//src/third_party/mtools:mtools_repositories.bzl", "mtools_repositories")
+mtools_repositories()

--- a/src/pkg/preloader/BUILD.bazel
+++ b/src/pkg/preloader/BUILD.bazel
@@ -14,6 +14,27 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+genrule(
+    name = "cidata",
+    srcs = [
+        "//src/cmd/provisioner:provisioner",
+        "//src/cmd/metadata_watcher:metadata_watcher",
+    ],
+    outs = ["cidata.img"],
+    tools = [
+        "@dosfstools//:mkfs.fat",
+        "@mtools//:mcopy",
+    ],
+    cmd = "\
+$(location @dosfstools//:mkfs.fat) -n CIDATA -S 512 -s 8 -C $@ 65536;\
+touch meta-data;\
+touch user-data;\
+$(location @mtools//:mcopy) -i $@ user-data ::/user-data;\
+$(location @mtools//:mcopy) -i $@ meta-data ::/meta-data;\
+$(location @mtools//:mcopy) -i $@ $(location //src/cmd/provisioner:provisioner) ::/provisioner;\
+$(location @mtools//:mcopy) -i $@ $(location //src/cmd/metadata_watcher:metadata_watcher) ::/metadata_watcher;"
+)
+
 go_library(
     name = "go_default_library",
     srcs = [

--- a/src/third_party/dosfstools/BUILD.bazel
+++ b/src/third_party/dosfstools/BUILD.bazel
@@ -1,0 +1,13 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/third_party/dosfstools/BUILD.dosfstools.bazel
+++ b/src/third_party/dosfstools/BUILD.dosfstools.bazel
@@ -1,0 +1,49 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "dosfstools_pkg",
+    lib_source = ":all_srcs",
+    configure_options = ["--disable-dependency-tracking"],
+    make_commands = [
+        # dosfstools requires the path to 'make' be present in the MAKE
+        # variable. Since the configure_make() rule doesn't do this for us, some
+        # magic is needed.
+        # 1. Set MAKE to the output of a 'shell' function that reads the path of
+        # the parent process. The parent process of the 'shell' function is the
+        # make process, run by configure_make() using the correct make program.
+        # 2. Write "$$PID" as "$$$PID$$". We do this because the
+        # configure_make() rule has a substitution that does "$$PID$$" ->
+        # "$PID".
+        "make MAKE='$(shell realpath /proc/$$$PPID$$/exe)'",
+        "make MAKE='$(shell realpath /proc/$$$PPID$$/exe)' install",
+    ],
+    out_bin_dir = "sbin",
+    binaries = ["mkfs.fat"],
+)
+
+filegroup(
+    name = "mkfs.fat",
+    srcs = [":dosfstools_pkg"],
+    output_group = "mkfs.fat",
+)

--- a/src/third_party/dosfstools/dosfstools_repositories.bzl
+++ b/src/third_party/dosfstools/dosfstools_repositories.bzl
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def dosfstools_repositories():
+    """Load all repositories needed for dosfstools."""
+
+    maybe(
+        http_archive,
+        name = "dosfstools",
+        build_file = Label("//src/third_party/dosfstools:BUILD.dosfstools.bazel"),
+        strip_prefix = "dosfstools-4.2",
+        urls = ["https://github.com/dosfstools/dosfstools/releases/download/v4.2/dosfstools-4.2.tar.gz"],
+        sha256 = "64926eebf90092dca21b14259a5301b7b98e7b1943e8a201c7d726084809b527",
+    )

--- a/src/third_party/mtools/BUILD.bazel
+++ b/src/third_party/mtools/BUILD.bazel
@@ -1,0 +1,13 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/third_party/mtools/BUILD.mtools.bazel
+++ b/src/third_party/mtools/BUILD.mtools.bazel
@@ -1,0 +1,34 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "mtools_pkg",
+    lib_source = ":all_srcs",
+    binaries = ["mcopy"],
+)
+
+filegroup(
+    name = "mcopy",
+    srcs = [":mtools_pkg"],
+    output_group = "mcopy",
+)

--- a/src/third_party/mtools/mtools_repositories.bzl
+++ b/src/third_party/mtools/mtools_repositories.bzl
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def mtools_repositories():
+    """Load all repositories needed for mtools."""
+
+    maybe(
+        http_archive,
+        name = "mtools",
+        build_file = Label("//src/third_party/mtools:BUILD.mtools.bazel"),
+        strip_prefix = "mtools-4.0.26",
+        urls = [
+            "https://mirror.bazel.build/ftp.gnu.org/gnu/mtools/mtools-4.0.26.tar.gz",
+            "http://ftp.gnu.org/gnu/mtools/mtools-4.0.26.tar.gz",
+        ],
+        sha256 = "b1adb6973d52b3b70b16047e682f96ef1b669d6b16894c9056a55f407e71cd0f",
+    )


### PR DESCRIPTION
When we integrate the provisioner into COS Customizer, we will transfer
the provisioner to the preload VM through a special vfat file system
image with the CIDATA label. This serves two purposes:
- Keeping the provisioner on a separate disk prevents the provisioner
  binary from using disk resources on the preload VM, which could result
  in unintuitive ENOSPC errors in customer scripts. The provisioner
  binary bundles a few things, making it somewhat large (~50MB)
- The cloud-init "nocloud" datasource searches for configuration in a
  vfat file system with the CIDATA label. This disk will be used for
  delivering the cloud-init user-data to the VM for systems that do not
  support the GCE datasource (e.g. images for non-GCE platforms)

To build this "cidata" image, we need two new tools: mkfs.fat and mcopy.
We pull in the "dosfstools" and "mtools" third party deps to use these
tools. The Bazel build rules for these packages are put in
//src/third_party. This change adds a genrule that uses these tools to
build the "cidata" vfat image.