### PR TITLE
preloader: Switch to a provisioner-based workflow

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,6 +21,8 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_deb")
 # gazelle:prefix github.com/GoogleCloudPlatform/cos-customizer
 gazelle(name = "gazelle")
 
+exports_files(glob(["src/data/**"]))
+
 genrule(
     name = "workspace_dir",
     outs = ["workspace"],

--- a/src/cmd/cos_customizer/finish_image_build.go
+++ b/src/cmd/cos_customizer/finish_image_build.go
@@ -340,7 +340,7 @@ func (f *FinishImageBuild) Execute(ctx context.Context, flags *flag.FlagSet, arg
 		}
 		update(outputImage.Labels, image.Labels)
 	}
-	if err := preloader.BuildImage(ctx, gcsClient, files, sourceImage, outputImage, buildConfig); err != nil {
+	if err := preloader.BuildImage(ctx, gcsClient, files, sourceImage, outputImage, buildConfig, provConfig); err != nil {
 		if _, ok := err.(*exec.ExitError); ok {
 			log.Printf("command failed: %s. See stdout logs for details", err)
 			return subcommands.ExitFailure

--- a/src/data/build_image.wf.json
+++ b/src/data/build_image.wf.json
@@ -5,31 +5,43 @@
     "output_image_name": {"Required": true, "Description": "Name of output image."},
     "output_image_family": {"Value": "", "Description": "Family of output image."},
     "output_image_project": {"Required": true, "Description": "Project of output image."},
+    "cidata_img": {"Required": true, "Description": "Path to CIDATA vfat image containing cloud-init user-data and the provisioner program. Must be in .tar.gz format."},
     "disk_size_gb": {"Value": "10", "Description": "The disk size to use for preloading."},
-    "oem_size":{"Value":"","Description": "The size for extended OEM partition."},
-    "oem_fs_size_4k":{"Value":"0","Description": "The filesystem size of extended OEM partition in unit of 4K sectors."},
-    "reclaim_sda3":{"Value":"false","Description": "Whether need to shrink and reclaim the space of /dev/sda3."},
-    "host_maintenance": {"Value": "MIGRATE", "Description": "VM behavior when there is maintenance."},
-    "user_build_context": {"Required": true, "Description": "GCS URL of the user build context."},
-    "builtin_build_context": {"Required": true, "Description": "GCS URL of the builtin build context."},
-    "state_file": {"Required": true, "Description": "GCS URL of the state file."},
-    "gcs_files": {
-      "Required": true,
-      "Description": "GCS URL of the directory containing arbitrary, step-specific data that does not belong in one of the build contexts."
-    },
-    "cloud_config": {"Required": true, "Description": "cloud-config file to run."}
+    "host_maintenance": {"Value": "MIGRATE", "Description": "VM behavior when there is maintenance."}
   },
   "Sources": {
-    "cloud-config": "${cloud_config}",
-    "daisy_ack": "/data/daisy_ack"
+    "cloud-config": "/data/startup.yaml",
+    "cidata.tar.gz_": "${cidata_img}"
   },
   "Steps": {
+    "copy-gcs": {
+      "CopyGCSObjects": [
+        {
+          "Source": "${SOURCESPATH}/cidata.tar.gz_",
+          "Destination": "${SOURCESPATH}/cidata.tar.gz"
+        }
+      ]
+    },
+    "create-cidata": {
+      "CreateImages": [
+        {
+          "Name": "cidata",
+          "RawDisk": {
+            "Source": "${SOURCESPATH}/cidata.tar.gz"
+          }
+        }
+      ]
+    },
     "setup": {
       "CreateDisks": [
         {
           "Name": "boot-disk",
           "SourceImage": "${source_image}",
           "SizeGb": "${disk_size_gb}"
+        },
+        {
+          "Name": "cidata-disk",
+          "SourceImage": "cidata"
         }
       ]
     },
@@ -37,20 +49,12 @@
       "CreateInstances": [
         {
           "Name": "preload-vm",
-          "Disks": [{"Source": "boot-disk"}],
+          "Disks": [{"Source": "boot-disk"}, {"Source": "cidata-disk"}],
           "guestAccelerators": {{.Accelerators}},
           "scheduling": {
             "onHostMaintenance": "${host_maintenance}"
           },
           "Metadata": {
-            "UserBuildContext": "${user_build_context}",
-            "BuiltinBuildContext": "${builtin_build_context}",
-            "StateFile": "${state_file}",
-            "GCSFiles": "${gcs_files}",
-            "DaisyAck": "${SCRATCHPATH}/daisy_ack",
-            "OEMSize":  "${oem_size}",
-            "OEMFSSize4K": "${oem_fs_size_4k}",
-            "ReclaimSDA3":"${reclaim_sda3}",
             "user-data": "${SOURCE:cloud-config}",
             "block-project-ssh-keys": "TRUE",
             "cos-update-strategy": "update_disabled"
@@ -62,41 +66,26 @@
         }
       ]
     },
-    "wait-preload-prepare": {
-      "WaitForInstancesSignal": [
-        {
-          "Name": "preload-vm",
-          "Interval": "2s",
-          "SerialOutput": {
-            "Port": 3,
-            "FailureMatch": "BuildFailed:",
-            "SuccessMatch": "Preparation done.",
-            "StatusMatch": "PrepareStatus:"
-          }
-        }
-      ]
-    },
-    "resize-disk":{ 
-      {{.ResizeDisks}}
-    },
-    "send-ack": {
-      "CopyGCSObjects": [
-        {
-          "Source": "${SOURCESPATH}/daisy_ack",
-          "Destination": "${SCRATCHPATH}/daisy_ack"
-        }
-      ]
-    },
     "wait-preload-finished": {
       "WaitForInstancesSignal": [
         {
           "Name": "preload-vm",
-          "Interval": "2s",
+          "Interval": "30s",
           "SerialOutput": {
             "Port": 3,
             "FailureMatch": "BuildFailed:",
             "SuccessMatch": "BuildSucceeded:",
             "StatusMatch": "BuildStatus:"
+          }
+        }
+      ]
+    },
+    "send-logging-end-msg": {
+      "UpdateInstancesMetadata": [
+        {
+          "Instance": "preload-vm",
+          "Metadata": {
+            "DaisyEnd": "ack"
           }
         }
       ]
@@ -109,6 +98,12 @@
           "Stopped": true
         }
       ]
+    },
+    "wait-for-resize": {
+      {{.WaitResize}}
+    },
+    "resize-disk": {
+      {{.ResizeDisks}}
     },
     "image": {
       "CreateImages": [
@@ -126,12 +121,14 @@
     }
   },
   "Dependencies": {
+    "create-cidata": ["copy-gcs"],
+    "setup": ["create-cidata"],
     "run": ["setup"],
-    "wait-preload-prepare": ["run"],
-    "resize-disk":["wait-preload-prepare"],
-    "send-ack": ["resize-disk"],
-    "wait-preload-finished": ["send-ack"],
-    "wait-vm-shutdown": ["wait-preload-finished"],
+    "wait-preload-finished": ["run"],
+    "wait-for-resize": ["run"],
+    "resize-disk": ["wait-for-resize"],
+    "send-logging-end-msg": ["wait-preload-finished", "resize-disk"],
+    "wait-vm-shutdown": ["send-logging-end-msg"],
     "image": ["wait-vm-shutdown"]
   }
 }

--- a/src/data/startup.yaml
+++ b/src/data/startup.yaml
@@ -1,0 +1,94 @@
+#cloud-config
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script runs customization scripts on a COS VM instance. It pulls
+# source from GCS and executes it.
+
+write_files:
+- path: /tmp/startup.sh
+  permissions: 0644
+  content: |
+    set -o errexit
+    set -o pipefail
+    set -o nounset
+
+    status() {
+      $@ 2>&1 | sed "s/^/BuildStatus: /"
+      return "${PIPESTATUS[0]}"
+    }
+
+    run_provisioner() {
+      status $@ && ret=$? || ret=$?
+      if [[ "${ret}" != 0 ]]; then
+        if [[ "${ret}" == 3 ]]; then
+          status echo "Rebooting..."
+          sleep 15 || :
+          reboot
+          while true; do sleep 1; done
+        fi
+        echo "BuildFailed: exiting due to errors"
+        # Under normal circumstances, Daisy will delete the VM once it sees
+        # "BuildFailed". But sometimes Daisy will die unexpectedly, so we want
+        # to shutdown ourselves to conserve resources. Let's give Daisy 5
+        # minutes to capture logs and delete the VM. If Daisy doesn't do that in
+        # 5 minutes, let's shut ourselves down.
+        sleep 300 || :
+        shutdown -h now
+        while true; do sleep 1; done
+      else
+        echo "BuildSucceeded: Build completed with no errors. Shutting down..."
+        # Once we shut down, the serial logs will be gone. We need to give Daisy
+        # time to capture the serial logs. Once Daisy is done capturing the
+        # serial logs, it will add the "DaisyEnd" metadata key. Let's wait for
+        # that key to appear (and shutdown anyway after 5 minutes).
+        /mnt/disks/cidata/metadata_watcher DaisyEnd
+        shutdown -h now
+        while true; do sleep 1; done
+      fi
+    }
+
+    main() {
+      status mkdir -p /mnt/disks/cidata
+      status mount /dev/disk/by-label/CIDATA /mnt/disks/cidata
+      if [[ ! -d /var/lib/.cos-customizer ]]; then
+        run_provisioner /mnt/disks/cidata/provisioner run --config=/mnt/disks/cidata/config.json
+      else
+        run_provisioner /mnt/disks/cidata/provisioner resume
+      fi
+    }
+
+    main
+- path: /etc/systemd/system/customizer.service
+  permissions: 0644
+  content: |
+    [Unit]
+    Description=Container-Optimized OS Customization Service
+    Wants=network-online.target gcr-online.target docker.service
+    After=network-online.target gcr-online.target docker.service
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=yes
+    User=root
+    ExecStart=/bin/bash /tmp/startup.sh
+    StandardOutput=tty
+    StandardError=tty
+    TTYPath=/dev/ttyS2
+
+runcmd:
+- echo "Starting startup service..."
+- systemctl daemon-reload
+- systemctl --no-block start customizer.service

--- a/src/pkg/fs/BUILD.bazel
+++ b/src/pkg/fs/BUILD.bazel
@@ -21,6 +21,10 @@ go_library(
         "copy.go",
         "file_system.go",
         "state_file.go",
+        "gzip.go",
+    ],
+    deps = [
+        "//src/pkg/utils:go_default_library",
     ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/fs",
     visibility = ["//visibility:public"],
@@ -31,6 +35,7 @@ go_test(
     srcs = [
         "build_context_test.go",
         "state_file_test.go",
+        "gzip_test.go",
     ],
     data = glob(
         ["testdata/**"],

--- a/src/pkg/fs/gzip.go
+++ b/src/pkg/fs/gzip.go
@@ -1,0 +1,45 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils"
+)
+
+// GzipFile compresses the file at the input path and saves the result at the
+// output path.
+func GzipFile(inPath, outPath string) (err error) {
+	in, err := os.Open(inPath)
+	if err != nil {
+		return err
+	}
+	defer utils.CheckClose(in, fmt.Sprintf("error closing %q", inPath), &err)
+	out, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer utils.CheckClose(out, fmt.Sprintf("error closing %q", outPath), &err)
+	gzOut := gzip.NewWriter(out)
+	defer utils.CheckClose(gzOut, fmt.Sprintf("error closing gzip writer for %q", outPath), &err)
+	if _, err := io.Copy(gzOut, in); err != nil {
+		return fmt.Errorf("error gzipping %q to %q: %v", inPath, outPath, err)
+	}
+	return nil
+}

--- a/src/pkg/fs/gzip_test.go
+++ b/src/pkg/fs/gzip_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGzipFile(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test-gzip-file-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	data, err := os.Create(filepath.Join(tmpDir, "data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer data.Close()
+	if _, err := io.Copy(data, bytes.NewReader([]byte("aaaaa"))); err != nil {
+		t.Fatal(err)
+	}
+	if err := data.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	outPath := filepath.Join(tmpDir, "out")
+	signature := fmt.Sprintf("GzipFile(%q, %q)", data.Name(), outPath)
+	if err := GzipFile(data.Name(), outPath); err != nil {
+		t.Fatalf("%s = %v; want nil", signature, err)
+	}
+	outFile, err := os.Open(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer outFile.Close()
+	uncompressed, err := gzip.NewReader(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer uncompressed.Close()
+	gotBytes, err := ioutil.ReadAll(uncompressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(gotBytes)
+	if want := "aaaaa"; got != want {
+		t.Errorf("%s = %q; want %q", signature, got, want)
+	}
+}

--- a/src/pkg/preloader/BUILD.bazel
+++ b/src/pkg/preloader/BUILD.bazel
@@ -17,6 +17,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 genrule(
     name = "cidata",
     srcs = [
+        "//:src/data/startup.yaml",
         "//src/cmd/provisioner:provisioner",
         "//src/cmd/metadata_watcher:metadata_watcher",
     ],
@@ -28,8 +29,7 @@ genrule(
     cmd = "\
 $(location @dosfstools//:mkfs.fat) -n CIDATA -S 512 -s 8 -C $@ 65536;\
 touch meta-data;\
-touch user-data;\
-$(location @mtools//:mcopy) -i $@ user-data ::/user-data;\
+$(location @mtools//:mcopy) -i $@ $(location //:src/data/startup.yaml) ::/user-data;\
 $(location @mtools//:mcopy) -i $@ meta-data ::/meta-data;\
 $(location @mtools//:mcopy) -i $@ $(location //src/cmd/provisioner:provisioner) ::/provisioner;\
 $(location @mtools//:mcopy) -i $@ $(location //src/cmd/metadata_watcher:metadata_watcher) ::/metadata_watcher;"
@@ -41,11 +41,16 @@ go_library(
         "gcs.go",
         "preload.go",
     ],
+    embedsrcs = [
+        ":cidata",
+    ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/preloader",
     visibility = ["//visibility:public"],
     deps = [
         "//src/pkg/config:go_default_library",
         "//src/pkg/fs:go_default_library",
+        "//src/pkg/utils:go_default_library",
+        "//src/pkg/provisioner:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
         "@org_golang_google_api//iterator:go_default_library",

--- a/src/pkg/provisioner/config.go
+++ b/src/pkg/provisioner/config.go
@@ -24,6 +24,13 @@ type StepConfig struct {
 	Args json.RawMessage
 }
 
+type BootDiskConfig struct {
+	OEMSize           string
+	OEMFSSize4K       uint64
+	ReclaimSDA3       bool
+	WaitForDiskResize bool
+}
+
 // Config defines a provisioning flow.
 type Config struct {
 	// BuildContexts identifies the build contexts that should be used during
@@ -33,12 +40,7 @@ type Config struct {
 	// gs:// addresses are supported.
 	BuildContexts map[string]string
 	// BootDisk defines how the boot disk should be configured.
-	BootDisk struct {
-		OEMSize           string
-		OEMFSSize4K       uint64
-		ReclaimSDA3       bool
-		WaitForDiskResize bool
-	}
+	BootDisk BootDiskConfig
 	// Steps are provisioning behaviors that can be run.
 	// The supported provisioning behaviors are:
 	//

--- a/src/pkg/provisioner/provisioner.go
+++ b/src/pkg/provisioner/provisioner.go
@@ -51,7 +51,7 @@ func setup(rootDir, dockerCredentialGCR string, systemd *systemdClient) error {
 	if err := systemd.stop("update-engine.service"); err != nil {
 		return err
 	}
-	if err := mountFunc("", filepath.Join(rootDir, "root"), "tmpfs", 0, ""); err != nil {
+	if err := mountFunc("tmpfs", filepath.Join(rootDir, "root"), "tmpfs", 0, ""); err != nil {
 		return fmt.Errorf("error mounting tmpfs at /root: %v", err)
 	}
 	cmd := exec.Command(dockerCredentialGCR, "configure-docker")


### PR DESCRIPTION
This change updates the preloader package to use a provisioner based
workflow. At a high level, this occurs by delivering the provisioner,
the provisioner config, and the cloud-init user-data to the VM through a
separate vfat file system. Some notable details:
- The Daisy workflow is much different to account for the cidata disk
  and the way the provisioner handles disk resizing
- The requirements of the actual cloud-init user-data behavior are much
  simpler now, so that startup behavior has been consolidated into a
  "startup.yaml" file. Originally the different pieces of the user-data
  were kept separate in Git to simplify development; editing a shell
  script that is hundreds of lines long is harder when that shell script
  is embedded in a yaml file. Since the new startup behavior is expected
  to be small and static, we can embed it in startup.yaml and simplify
  the preloader logic.
- The "daisy_ack" has been moved to be GCE metadata based instead of GCS
  based. Since Daisy is already a GCE-specific tool, depending on GCE
  metadata for this interface makes sense in the long run. The
  "daisy_ack" logic has also been moved around a bit to allow us to poll
  the serial logs less frequently.
- Some small provisioner bugs caught by ./run_tests are also fixed in
  this change.

./run_tests passes.