### PR TITLE
Run some cleanup tools on the tree

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,7 +16,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@package_bundle//file:packages.bzl", "packages")
-load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_deb")
+load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
 
 # gazelle:prefix github.com/GoogleCloudPlatform/cos-customizer
 gazelle(name = "gazelle")
@@ -37,7 +37,6 @@ genrule(
 
 container_image(
     name = "veritysetup",
-    repository = "veritysetup",
     debs = [
         packages["coreutils"],
         packages["tar"],
@@ -59,6 +58,7 @@ container_image(
         packages["libm17n-0"],
         packages["libgpg-error0"],
     ],
+    repository = "veritysetup",
     visibility = ["//visibility:public"],
 )
 
@@ -83,8 +83,8 @@ container_image(
         packages["mtools"],
     ],
     files = [
-        ":workspace_dir",
         ":tmp_dir",
+        ":workspace_dir",
     ],
     tars = [
         ":data_tar",
@@ -94,7 +94,7 @@ container_image(
 go_image(
     name = "cos_customizer",
     base = ":cos_customizer_base",
-    embed = ["//src/cmd/cos_customizer:go_default_library"],
+    embed = ["//src/cmd/cos_customizer:cos_customizer_lib"],
     goarch = "amd64",
     goos = "linux",
     pure = "on",

--- a/src/cmd/cos_customizer/BUILD.bazel
+++ b/src/cmd/cos_customizer/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "cos_customizer_lib",
     srcs = [
         "disable_auto_update.go",
         "finish_image_build.go",
@@ -29,24 +29,24 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/cmd/cos_customizer",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/pkg/config:go_default_library",
-        "//src/pkg/fs:go_default_library",
-        "//src/pkg/gce:go_default_library",
-        "//src/pkg/preloader:go_default_library",
-        "//src/pkg/tools/partutil:go_default_library",
-        "//src/pkg/utils:go_default_library",
-        "//src/pkg/provisioner:go_default_library",
-        "@com_github_google_subcommands//:go_default_library",
-        "@com_google_cloud_go_storage//:go_default_library",
-        "@org_golang_google_api//compute/v1:go_default_library",
-        "@org_golang_google_api//iterator:go_default_library",
-        "@org_golang_google_api//option:go_default_library",
-        "@org_golang_x_oauth2//google:go_default_library",
+        "//src/pkg/config",
+        "//src/pkg/fs",
+        "//src/pkg/gce",
+        "//src/pkg/preloader",
+        "//src/pkg/provisioner",
+        "//src/pkg/tools/partutil",
+        "//src/pkg/utils",
+        "@com_github_google_subcommands//:subcommands",
+        "@com_google_cloud_go_storage//:storage",
+        "@org_golang_google_api//compute/v1:compute",
+        "@org_golang_google_api//iterator",
+        "@org_golang_google_api//option",
+        "@org_golang_x_oauth2//google",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "cos_customizer_test",
     srcs = [
         "finish_image_build_test.go",
         "flag_vars_test.go",
@@ -54,20 +54,21 @@ go_test(
         "run_script_test.go",
         "start_image_build_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":cos_customizer_lib"],
     deps = [
-        "//src/pkg/config:go_default_library",
-        "//src/pkg/fakes:go_default_library",
-        "//src/pkg/fs:go_default_library",
-        "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_google_subcommands//:go_default_library",
-        "@com_google_cloud_go_storage//:go_default_library",
-        "@org_golang_google_api//compute/v1:go_default_library",
+        "//src/pkg/config",
+        "//src/pkg/fakes",
+        "//src/pkg/fs",
+        "//src/pkg/provisioner",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_subcommands//:subcommands",
+        "@com_google_cloud_go_storage//:storage",
+        "@org_golang_google_api//compute/v1:compute",
     ],
 )
 
 go_binary(
     name = "cos_customizer",
-    embed = [":go_default_library"],
+    embed = [":cos_customizer_lib"],
     visibility = ["//visibility:public"],
 )

--- a/src/cmd/handle_disk_layout/BUILD.bazel
+++ b/src/cmd/handle_disk_layout/BUILD.bazel
@@ -15,15 +15,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "handle_disk_layout_lib",
     srcs = ["handle_disk_layout_bin.go"],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/cmd/handle_disk_layout",
     visibility = ["//visibility:private"],
-    deps = ["//src/pkg/tools:go_default_library"],
+    deps = ["//src/pkg/tools"],
 )
 
 go_binary(
     name = "handle_disk_layout_bin",
-    embed = [":go_default_library"],
+    embed = [":handle_disk_layout_lib"],
     visibility = ["//visibility:public"],
 )

--- a/src/cmd/provisioner/BUILD.bazel
+++ b/src/cmd/provisioner/BUILD.bazel
@@ -1,7 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "provisioner_lib",
     srcs = [
         "main.go",
         "resume.go",
@@ -10,14 +24,14 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/cmd/provisioner",
     visibility = ["//visibility:private"],
     deps = [
-        "//src/pkg/provisioner:go_default_library",
-        "@com_github_google_subcommands//:go_default_library",
-        "@com_google_cloud_go_storage//:go_default_library",
+        "//src/pkg/provisioner",
+        "@com_github_google_subcommands//:subcommands",
+        "@com_google_cloud_go_storage//:storage",
     ],
 )
 
 go_binary(
     name = "provisioner",
-    embed = [":go_default_library"],
+    embed = [":provisioner_lib"],
     visibility = ["//visibility:public"],
 )

--- a/src/pkg/config/BUILD.bazel
+++ b/src/pkg/config/BUILD.bazel
@@ -15,23 +15,23 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "config",
     srcs = ["config.go"],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/config",
     visibility = ["//visibility:public"],
     deps = [
-        "@org_golang_google_api//compute/v1:go_default_library",
-        "//src/pkg/utils:go_default_library",
+        "//src/pkg/utils",
+        "@org_golang_google_api//compute/v1:compute",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "config_test",
     srcs = ["config_test.go"],
     data = glob(["testdata/**"]),
-    embed = [":go_default_library"],
+    embed = [":config"],
     deps = [
-        "@com_github_google_go_cmp//cmp:go_default_library",
-        "@org_golang_google_api//compute/v1:go_default_library",
+        "@com_github_google_go_cmp//cmp",
+        "@org_golang_google_api//compute/v1:compute",
     ],
 )

--- a/src/pkg/fakes/BUILD.bazel
+++ b/src/pkg/fakes/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "fakes",
     testonly = True,
     srcs = [
         "gce.go",
@@ -25,26 +25,26 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/fakes",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_google_cloud_go_storage//:go_default_library",
-        "@org_golang_google_api//compute/v1:go_default_library",
-        "@org_golang_google_api//googleapi:go_default_library",
-        "@org_golang_google_api//option:go_default_library",
+        "@com_google_cloud_go_storage//:storage",
+        "@org_golang_google_api//compute/v1:compute",
+        "@org_golang_google_api//googleapi",
+        "@org_golang_google_api//option",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "fakes_test",
     srcs = [
         "gce_test.go",
         "gcs_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":fakes"],
     deps = [
-        "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
-        "@com_google_cloud_go_storage//:go_default_library",
-        "@org_golang_google_api//compute/v1:go_default_library",
-        "@org_golang_google_api//googleapi:go_default_library",
-        "@org_golang_google_api//iterator:go_default_library",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
+        "@com_google_cloud_go_storage//:storage",
+        "@org_golang_google_api//compute/v1:compute",
+        "@org_golang_google_api//googleapi",
+        "@org_golang_google_api//iterator",
     ],
 )

--- a/src/pkg/fs/BUILD.bazel
+++ b/src/pkg/fs/BUILD.bazel
@@ -15,22 +15,22 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "fs",
     srcs = [
         "build_context.go",
         "copy.go",
         "file_system.go",
         "gzip.go",
     ],
-    deps = [
-        "//src/pkg/utils:go_default_library",
-    ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/fs",
     visibility = ["//visibility:public"],
+    deps = [
+        "//src/pkg/utils",
+    ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "fs_test",
     srcs = [
         "build_context_test.go",
         "gzip_test.go",
@@ -39,5 +39,5 @@ go_test(
         ["testdata/**"],
         exclude_directories = 0,
     ),
-    embed = [":go_default_library"],
+    embed = [":fs"],
 )

--- a/src/pkg/gce/BUILD.bazel
+++ b/src/pkg/gce/BUILD.bazel
@@ -15,24 +15,24 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "gce",
     srcs = ["gce.go"],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/gce",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/pkg/config:go_default_library",
-        "@org_golang_google_api//compute/v1:go_default_library",
-        "@org_golang_google_api//googleapi:go_default_library",
+        "//src/pkg/config",
+        "@org_golang_google_api//compute/v1:compute",
+        "@org_golang_google_api//googleapi",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "gce_test",
     srcs = ["gce_test.go"],
-    embed = [":go_default_library"],
+    embed = [":gce"],
     deps = [
-        "//src/pkg/config:go_default_library",
-        "//src/pkg/fakes:go_default_library",
-        "@org_golang_google_api//compute/v1:go_default_library",
+        "//src/pkg/config",
+        "//src/pkg/fakes",
+        "@org_golang_google_api//compute/v1:compute",
     ],
 )

--- a/src/pkg/preloader/BUILD.bazel
+++ b/src/pkg/preloader/BUILD.bazel
@@ -18,25 +18,25 @@ genrule(
     name = "cidata",
     srcs = [
         "//:src/data/startup.yaml",
-        "//src/cmd/provisioner:provisioner",
-        "//src/cmd/metadata_watcher:metadata_watcher",
+        "//src/cmd/provisioner",
+        "//src/cmd/metadata_watcher",
     ],
     outs = ["cidata.img"],
-    tools = [
-        "@dosfstools//:mkfs.fat",
-        "@mtools//:mcopy",
-    ],
     cmd = "\
 $(location @dosfstools//:mkfs.fat) -n CIDATA -S 512 -s 8 -C $@ 65536;\
 touch meta-data;\
 $(location @mtools//:mcopy) -i $@ $(location //:src/data/startup.yaml) ::/user-data;\
 $(location @mtools//:mcopy) -i $@ meta-data ::/meta-data;\
 $(location @mtools//:mcopy) -i $@ $(location //src/cmd/provisioner:provisioner) ::/provisioner;\
-$(location @mtools//:mcopy) -i $@ $(location //src/cmd/metadata_watcher:metadata_watcher) ::/metadata_watcher;"
+$(location @mtools//:mcopy) -i $@ $(location //src/cmd/metadata_watcher:metadata_watcher) ::/metadata_watcher;",
+    tools = [
+        "@dosfstools//:mkfs.fat",
+        "@mtools//:mcopy",
+    ],
 )
 
 go_library(
-    name = "go_default_library",
+    name = "preloader",
     srcs = [
         "gcs.go",
         "preload.go",
@@ -47,30 +47,29 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/preloader",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/pkg/config:go_default_library",
-        "//src/pkg/fs:go_default_library",
-        "//src/pkg/utils:go_default_library",
-        "//src/pkg/provisioner:go_default_library",
-        "@com_google_cloud_go_storage//:go_default_library",
-        "@in_gopkg_yaml_v2//:go_default_library",
-        "@org_golang_google_api//iterator:go_default_library",
+        "//src/pkg/config",
+        "//src/pkg/fs",
+        "//src/pkg/provisioner",
+        "//src/pkg/utils",
+        "@com_google_cloud_go_storage//:storage",
+        "@org_golang_google_api//iterator",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "preloader_test",
     srcs = [
         "gcs_test.go",
         "preload_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":preloader"],
     deps = [
-        "//src/pkg/config:go_default_library",
-        "//src/pkg/fakes:go_default_library",
-        "//src/pkg/fs:go_default_library",
-        "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
-        "@in_gopkg_yaml_v2//:go_default_library",
-        "@org_golang_google_api//compute/v1:go_default_library",
+        "//src/pkg/config",
+        "//src/pkg/fakes",
+        "//src/pkg/fs",
+        "//src/pkg/provisioner",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
+        "@org_golang_google_api//compute/v1:compute",
     ],
 )

--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//extras:embed_data.bzl", "go_embed_data")
 
@@ -20,7 +34,7 @@ genrule(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "provisioner",
     srcs = [
         "config.go",
         "disable_auto_update_step.go",
@@ -40,21 +54,21 @@ go_library(
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/pkg/tools:go_default_library",
-        "//src/pkg/tools/partutil:go_default_library",
-        "//src/pkg/utils:go_default_library",
-        "@com_google_cloud_go_storage//:go_default_library",
-        "@org_golang_x_sys//unix:go_default_library",
+        "//src/pkg/tools",
+        "//src/pkg/tools/partutil",
+        "//src/pkg/utils",
+        "@com_google_cloud_go_storage//:storage",
+        "@org_golang_x_sys//unix",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "provisioner_test",
     srcs = ["provisioner_test.go"],
     data = glob(["testdata/**"]),
-    embed = [":go_default_library"],
+    embed = [":provisioner"],
     deps = [
-        "//src/pkg/fakes:go_default_library",
-        "@org_golang_x_sys//unix:go_default_library",
+        "//src/pkg/fakes",
+        "@org_golang_x_sys//unix",
     ],
 )

--- a/src/pkg/tools/BUILD.bazel
+++ b/src/pkg/tools/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "tools",
     srcs = [
         "disable_systemd_service.go",
         "extend_oem_partition.go",
@@ -24,12 +24,12 @@ go_library(
     ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/tools",
     visibility = ["//visibility:public"],
-    deps = ["//src/pkg/tools/partutil:go_default_library"],
+    deps = ["//src/pkg/tools/partutil"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "tools_test",
     srcs = ["handle_disk_layout_test.go"],
-    embed = [":go_default_library"],
-    deps = ["//src/pkg/tools/partutil/partutiltest:go_default_library"],
+    embed = [":tools"],
+    deps = ["//src/pkg/tools/partutil/partutiltest"],
 )

--- a/src/pkg/tools/partutil/BUILD.bazel
+++ b/src/pkg/tools/partutil/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "partutil",
     srcs = [
         "extend_partition.go",
         "grub_utils.go",
@@ -28,7 +28,7 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "partutil_test",
     srcs = [
         "extend_partition_test.go",
         "handle_partition_table_test.go",
@@ -36,6 +36,6 @@ go_test(
         "move_partition_test.go",
     ],
     data = glob(["testdata/**"]),
-    embed = [":go_default_library"],
-    deps = ["//src/pkg/tools/partutil/partutiltest:go_default_library"],
+    embed = [":partutil"],
+    deps = ["//src/pkg/tools/partutil/partutiltest"],
 )

--- a/src/pkg/tools/partutil/partutiltest/BUILD.bazel
+++ b/src/pkg/tools/partutil/partutiltest/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "partutiltest",
     srcs = ["set_test_env.go"],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/tools/partutil/partutiltest",
     visibility = ["//visibility:public"],

--- a/src/pkg/utils/BUILD.bazel
+++ b/src/pkg/utils/BUILD.bazel
@@ -1,7 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "utils",
     srcs = ["utils.go"],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/utils",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Let's run gazelle to standardize our BUILD files. Let's also add license
headers to files that are missing them.