### PR TITLE
Update cos-gpu-installer to v20210319

### DIFF
--- a/src/cmd/cos_customizer/install_gpu.go
+++ b/src/cmd/cos_customizer/install_gpu.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	gpuScript          = "install_gpu.sh"
-	installerContainer = "gcr.io/cos-cloud/cos-gpu-installer:v20210204"
+	installerContainer = "gcr.io/cos-cloud/cos-gpu-installer:v20210319"
 )
 
 // TODO(b/121332360): Move most GPU functionality to cos-gpu-installer


### PR DESCRIPTION
This will remove a dependency on the host to allow installing GPU
drivers on hosts without the GCE userspace installed.