### PR TITLE
Run unit tests with mtools installed

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,9 +13,18 @@
 # limitations under the License.
 
 steps:
-- name: 'gcr.io/cloud-builders/bazel'
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    cat <<EOF | docker build -t bazel -
+    FROM gcr.io/cloud-builders/bazel
+    RUN apt-get update && apt-get install -y mtools
+    EOF
+- name: 'bazel'
   args: ['test', '--spawn_strategy=standalone','--','...','-//src/pkg/tools/...']
-- name: 'gcr.io/cloud-builders/bazel'
+- name: 'bazel'
   args: ['run', '--spawn_strategy=standalone', ':cos_customizer', '--', '--norun']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['tag', 'bazel:cos_customizer', 'gcr.io/${_OUTPUT_PROJECT}/cos-customizer:${TAG_NAME}']


### PR DESCRIPTION
We use mtools to copy data onto the CIDATA disk image (which is a vfat
file system). Unit tests depend on mtools being installed in the
environment. Let's install mtools in the release workflow so that unit
tests pass there.

We install mtools by building a local container in the cloud build job
that is gcr.io/cloud-builders/bazel + mtools. We then use this container
in place of gcr.io/cloud-builders/bazel.