### PR TITLE
Break dependency on host's docker-credential-gcr

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,6 +68,13 @@ git_repository(
     shallow_since = "1591135967 -0700",
 )
 
+git_repository(
+    name = "com_github_googlecloudplatform_docker_credential_gcr",
+    commit = "6093d30b51d725877bc6971aa6700153c1a364f1",
+    remote = "https://github.com/GoogleCloudPlatform/docker-credential-gcr",
+    shallow_since = "1613169008 -0800",
+)
+
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
@@ -78,6 +85,11 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_to
 go_rules_dependencies()
 
 go_register_toolchains(version="1.16")
+
+load("//:deps.bzl", "go_mod_deps")
+
+# gazelle:repository_macro deps.bzl%go_mod_deps
+go_mod_deps()
 
 rules_pkg_dependencies()
 
@@ -169,11 +181,6 @@ dpkg_list(
         "@debian_stretch//file:Packages.json",
     ],
 )
-
-load("//:deps.bzl", "go_mod_deps")
-
-# gazelle:repository_macro deps.bzl%go_mod_deps
-go_mod_deps()
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 rules_foreign_cc_dependencies()

--- a/deps.bzl
+++ b/deps.bzl
@@ -292,8 +292,8 @@ def go_mod_deps():
     go_repository(
         name = "in_gopkg_yaml_v2",
         importpath = "gopkg.in/yaml.v2",
-        sum = "h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=",
-        version = "v2.4.0",
+        sum = "h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=",
+        version = "v2.2.2",
     )
     go_repository(
         name = "io_opencensus_go",
@@ -406,8 +406,8 @@ def go_mod_deps():
     go_repository(
         name = "org_golang_x_sys",
         importpath = "golang.org/x/sys",
-        sum = "h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=",
-        version = "v0.0.0-20210124154548-22da62e12c0c",
+        sum = "h1:cdsMqa2nXzqlgs183pHxtvoVwU7CyzaCTAUOg94af4c=",
+        version = "v0.0.0-20210503173754-0981d6026fa6",
     )
     go_repository(
         name = "org_golang_x_term",

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/go-cmp v0.5.4
 	github.com/google/subcommands v1.2.0
 	golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c
-	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
+	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6
 	google.golang.org/api v0.39.0
-	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 h1:cdsMqa2nXzqlgs183pHxtvoVwU7CyzaCTAUOg94af4c=
+golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -476,9 +477,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/src/cmd/provisioner/main.go
+++ b/src/cmd/provisioner/main.go
@@ -48,15 +48,14 @@ func main() {
 		os.Exit(int(subcommands.ExitFailure))
 	}
 	deps := provisioner.Deps{
-		GCSClient:           gcsClient,
-		TarCmd:              "tar",
-		SystemctlCmd:        "systemctl",
-		DockerCredentialGCR: "docker-credential-gcr",
-		RootdevCmd:          "rootdev",
-		CgptCmd:             "cgpt",
-		Resize2fsCmd:        "resize2fs",
-		E2fsckCmd:           "e2fsck",
-		RootDir:             "/",
+		GCSClient:    gcsClient,
+		TarCmd:       "tar",
+		SystemctlCmd: "systemctl",
+		RootdevCmd:   "rootdev",
+		CgptCmd:      "cgpt",
+		Resize2fsCmd: "resize2fs",
+		E2fsckCmd:    "e2fsck",
+		RootDir:      "/",
 	}
 	var exitCode int
 	ret := subcommands.Execute(ctx, deps, &exitCode)

--- a/src/pkg/provisioner/BUILD.bazel
+++ b/src/pkg/provisioner/BUILD.bazel
@@ -33,6 +33,13 @@ genrule(
     cmd = "cp $< $@",
 )
 
+genrule(
+    name = "docker_credential_gcr",
+    srcs = ["@com_github_googlecloudplatform_docker_credential_gcr//:docker-credential-gcr"],
+    outs = ["docker-credential-gcr"],
+    cmd = "cp $< $@",
+)
+
 go_library(
     name = "provisioner",
     srcs = [
@@ -50,6 +57,7 @@ go_library(
     embedsrcs = [
         ":handle_disk_layout.bin",
         ":veritysetup.img",
+        ":docker_credential_gcr",
     ],
     importpath = "github.com/GoogleCloudPlatform/cos-customizer/src/pkg/provisioner",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
To allow running cos-customizer in environments that do not have
docker-credential-gcr installed, we can package docker-credential-gcr
with cos-customizer. We do this by embedding docker-credential-gcr into
the provisioner and writing it out to provisioner state when it is
needed.

Since the stateful partition on COS is not executable by default, we
mount a bind mount to execute docker-credential-gcr from.

I needed to re-order dependencies in WORKSPACE for the build to succeed
(we need a newer version of golang.org/x/sys for unix.MS_NOSYMFOLLOW).