### PR TITLE
Update cos-gpu-installer to latest version

### DIFF
--- a/src/cmd/cos_customizer/install_gpu.go
+++ b/src/cmd/cos_customizer/install_gpu.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	gpuScript          = "install_gpu.sh"
-	installerContainer = "gcr.io/cos-cloud/cos-gpu-installer:v20210319"
+  installerContainer = "gcr.io/cos-cloud/cos-gpu-installer:v20210714"
 )
 
 // TODO(b/121332360): Move most GPU functionality to cos-gpu-installer


### PR DESCRIPTION
Fixes an issue where GPU builds fail if the standalone toolchain
includes hard links to the rust standard library.