### PR TITLE
Update to latest cos-gpu-installer

### DIFF
--- a/src/cmd/cos_customizer/install_gpu.go
+++ b/src/cmd/cos_customizer/install_gpu.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	gpuScript          = "install_gpu.sh"
-  installerContainer = "gcr.io/cos-cloud/cos-gpu-installer:v20210714"
+	installerContainer = "gcr.io/cos-cloud/cos-gpu-installer:v20210715"
 )
 
 // TODO(b/121332360): Move most GPU functionality to cos-gpu-installer

--- a/testing/gpu_test.yaml
+++ b/testing/gpu_test.yaml
@@ -38,6 +38,9 @@ steps:
                   --async --format='value(ID)' ."
                "gcloud builds submit --config=testing/gpu_test/gpu_test.yaml\
                   --substitutions=_DRIVER_VERSION=450.51.06,_INPUT_IMAGE=cos-rc-85-13310-1040-0\
+                  --async --format='value(ID)' ."
+               "gcloud builds submit --config=testing/gpu_test/gpu_test.yaml\
+                  --substitutions=_DRIVER_VERSION=460.32.03,_INPUT_IMAGE=cos-89-16108-403-42\
                   --async --format='value(ID)' .")
     build_ids=()
     exit_code=0


### PR DESCRIPTION
Fixes an issue on M89 where rust toolchain elements were not properly
stripped.

Also add a GPU test for M89 to catch this sort of problem before
release.