### PR TITLE
Only remove customizer.service at shutdown time

### DIFF
--- a/src/data/startup.yaml
+++ b/src/data/startup.yaml
@@ -88,6 +88,7 @@ write_files:
     RemainAfterExit=yes
     User=root
     ExecStart=/bin/bash /tmp/startup.sh
+    ExecStopPost=/bin/bash -c 'rm /etc/systemd/system/customizer.service'
     StandardOutput=tty
     StandardError=tty
     TTYPath=/dev/ttyS2
@@ -96,4 +97,3 @@ runcmd:
 - echo "Starting startup service..."
 - systemctl daemon-reload
 - systemctl --no-block start customizer.service
-- rm /etc/systemd/system/customizer.service

--- a/testing/ubuntu_ova_test/preload_test.cfg
+++ b/testing/ubuntu_ova_test/preload_test.cfg
@@ -82,12 +82,23 @@ write_files:
         echo "testWorkdirClean pass"
       }
 
+      testServiceClean() {
+        if [[ -f "/etc/systemd/system/customizer.service" ]]; then
+          echo "/etc/systemd/system/customizer.service exists"
+          echo "testServiceClean fail"
+          RESULT="fail"
+          return
+        fi
+        echo "testServiceClean pass"
+      }
+
       main() {
         RESULT="pass"
         testHello
         testUbuntuImage
         testHomeDir
         testWorkdirClean
+        testServiceClean
         if [[ "${RESULT}" == "fail" ]]; then
           exit 1
         fi


### PR DESCRIPTION
Removing a systemd unit file changes the behavior of the unit. In
particular, the value of "TimeoutStartUSec" changes from "infinity"
(desired) to "1m 30s" (not desired) when the unit file is deleted.
Deleting customizer.service early in the preload process increases the
risk of TimeoutStartUSec kicking in and killing customizer.service. To
minimize this risk, let's only delete the unit file during system
shutdown (the stop behavior of customizer.service is invoked at shutdown
time).

A test is added to ensure that the unit file is indeed deleted. The test
can only be run on Ubuntu, because /etc is stateless on COS.